### PR TITLE
v2.5.4: 更新禁漫APP最新的接口域名（v1.6.6）

### DIFF
--- a/src/jmcomic/__init__.py
+++ b/src/jmcomic/__init__.py
@@ -2,7 +2,7 @@
 # 被依赖方 <--- 使用方
 # config <--- entity <--- toolkit <--- client <--- option <--- downloader
 
-__version__ = '2.5.3'
+__version__ = '2.5.4'
 
 from .api import *
 from .jm_plugin import *

--- a/src/jmcomic/jm_config.py
+++ b/src/jmcomic/jm_config.py
@@ -106,23 +106,17 @@ class JmModuleConfig:
 
     # 移动端图片域名
     DOMAIN_IMAGE_LIST = str_to_list('''
-    cdn-msp.jmapiproxy1.monster
-    cdn-msp2.jmapiproxy1.monster
-    cdn-msp.jmapiproxy1.cc
-    cdn-msp.jmapiproxy2.cc
-    cdn-msp.jmapiproxy3.cc
-    cdn-msp.jmapiproxy4.cc
+    cdn-msp.jmapinodeudzn.net
+    cdn-msp2.jmapinodeudzn.net
 
     ''')
 
     # 移动端API域名
     DOMAIN_API_LIST = str_to_list('''
+    www.jmapinodeudzn.xyz
+    www.jmapinode.vip
     www.jmapinode.biz
-    www.jmapinode1.top
-    www.jmapinode2.top
-    www.jmapinode3.top
-    www.jmapinode.top
-    
+    www.jmapinode.xyz
     ''')
 
     # 网页端域名配置


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `jmcomic` package version to 2.5.4.
- **Refactor**
	- Updated domain names in the configuration for better connectivity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->