### PR TITLE
v2.5.15: 接口更新，网页端登录成功的状态码由301更新为200

### DIFF
--- a/src/jmcomic/__init__.py
+++ b/src/jmcomic/__init__.py
@@ -2,7 +2,7 @@
 # 被依赖方 <--- 使用方
 # config <--- entity <--- toolkit <--- client <--- option <--- downloader
 
-__version__ = '2.5.14'
+__version__ = '2.5.15'
 
 from .api import *
 from .jm_plugin import *

--- a/src/jmcomic/jm_client_impl.py
+++ b/src/jmcomic/jm_client_impl.py
@@ -402,7 +402,7 @@ class JmHtmlClient(AbstractJmClient):
                          allow_redirects=False,
                          )
 
-        if resp.status_code != 301:
+        if resp.status_code != 200:
             ExceptionTool.raises_resp(f'登录失败，状态码为{resp.status_code}', resp)
 
         orig_cookies = self.get_meta_data('cookies') or {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Incremented version from `2.5.14` to `2.5.15`.

- **Bug Fixes**
  - Improved login functionality by correctly handling HTTP response status code `200` instead of `301`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->