### PR TITLE
使用图片时，过滤文件系统创建的隐藏文件

### DIFF
--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -852,12 +852,17 @@ class LongImgPlugin(JmOptionPlugin):
 
         images = [Image.open(img_path) for img_path in img_paths]
 
+        try:
+            resample_method = Image.Resampling.LANCZOS
+        except AttributeError:
+            resample_method = Image.LANCZOS
+
         min_img_width = min(img.width for img in images)
         total_height = 0
         for i, img in enumerate(images):
             if img.width > min_img_width:
                 images[i] = img.resize((min_img_width, int(img.height * min_img_width / img.width)),
-                                       Image.Resampling.LANCZOS)
+                                       resample=resample_method)
             total_height += images[i].height
 
         long_img = Image.new('RGB', (min_img_width, total_height))
@@ -867,6 +872,7 @@ class LongImgPlugin(JmOptionPlugin):
             y_offset += img.height
 
         long_img.save(long_img_path)
+        [img.close() for img in images]
 
         return img_paths
 

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -799,6 +799,84 @@ class Img2pdfPlugin(JmOptionPlugin):
         return pdf_dir
 
 
+class LongImgPlugin(JmOptionPlugin):
+    plugin_key = 'long_img'
+
+    def invoke(self,
+               photo: JmPhotoDetail = None,
+               album: JmAlbumDetail = None,
+               downloader=None,
+               img_dir=None,
+               filename_rule='Pid',
+               delete_original_file=False,
+               **kwargs,
+               ):
+        if photo is None and album is None:
+            jm_log('wrong_usage', 'long_img必须运行在after_photo或after_album时')
+
+        try:
+            from PIL import Image
+        except ImportError:
+            self.warning_lib_not_install('PIL')
+            return
+
+        self.delete_original_file = delete_original_file
+
+        # 处理文件夹配置
+        img_dir = self.get_img_dir(img_dir)
+
+        # 处理生成的长图文件的路径
+        filename = DirRule.apply_rule_directly(album, photo, filename_rule)
+
+        # 长图路径
+        long_img_path = os.path.join(img_dir, f'{filename}.png')
+
+        # 调用 PIL 把 photo_dir 下的所有图片合并为长图
+        img_path_ls = self.write_img_2_long_img(long_img_path, album, photo)
+        self.log(f'Convert Successfully: JM{album or photo} → {long_img_path}')
+
+        # 执行删除
+        self.execute_deletion(img_path_ls)
+
+    def write_img_2_long_img(self, long_img_path, album: JmAlbumDetail, photo: JmPhotoDetail) -> list[str]:
+        import itertools
+        from PIL import Image
+
+        if album is None:
+            img_dir_items = [self.option.decide_image_save_dir(photo)]
+        else:
+            img_dir_items = [self.option.decide_image_save_dir(photo) for photo in album]
+
+        img_paths = list(itertools.chain(*map(files_of_dir, img_dir_items)))
+        img_paths = sorted(img_paths)
+
+        images = [Image.open(img_path) for img_path in img_paths]
+
+        min_img_width = min(img.width for img in images)
+        total_height = 0
+        for i, img in enumerate(images):
+            if img.width > min_img_width:
+                images[i] = img.resize((min_img_width, int(img.height * min_img_width / img.width)),
+                                       Image.Resampling.LANCZOS)
+            total_height += images[i].height
+
+        long_img = Image.new('RGB', (min_img_width, total_height))
+        y_offset = 0
+        for img in images:
+            long_img.paste(img, (0, y_offset))
+            y_offset += img.height
+
+        long_img.save(long_img_path)
+
+        return img_paths
+
+    @staticmethod
+    def get_img_dir(img_dir: str | None) -> str:
+        img_dir = fix_filepath(img_dir or os.getcwd())
+        mkdir_if_not_exists(img_dir)
+        return img_dir
+
+
 class JmServerPlugin(JmOptionPlugin):
     plugin_key = 'jm_server'
 

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -847,7 +847,8 @@ class LongImgPlugin(JmOptionPlugin):
         else:
             img_dir_items = [self.option.decide_image_save_dir(photo) for photo in album]
 
-        img_paths = list(itertools.chain(*map(files_of_dir, img_dir_items)))
+        img_paths = itertools.chain(*map(files_of_dir, img_dir_items))
+        img_paths = filter(lambda x: not x.startswith('.'), img_paths)  # 过滤系统文件
         img_paths = sorted(img_paths)
 
         images = [Image.open(img_path) for img_path in img_paths]


### PR DESCRIPTION
有些文件系统会自动创建隐藏文件用于索引，使用下载的图片进行后续操作时会导致错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to create long images by merging multiple images vertically.
	- Added a new plugin class to enhance the existing plugin system.
- **Improvements**
	- Implemented input validation and directory management for saving long images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->