### PR TITLE
v2.5.25: 支持Client直接下载无混淆图片，添加docs示例

### DIFF
--- a/assets/docs/sources/tutorial/0_common_usage.md
+++ b/assets/docs/sources/tutorial/0_common_usage.md
@@ -38,7 +38,7 @@ download_album(123, option)
 option.download_album(123)
 ```
 
-## 获取本子/章节/图片的实体类
+## 获取本子/章节/图片的实体类，下载图片
 
 ```python
 from jmcomic import *
@@ -59,7 +59,13 @@ def fetch(photo: JmPhotoDetail):
     image: JmImageDetail
     for image in photo:
         print(f'图片url: {image.img_url}')
-
+        
+    # 下载单个图片
+    client.download_by_image_detail(image, './a.jpg')
+    # 如果是已知未混淆的图片，也可以直接使用url来下载
+    random_image_domain = JmModuleConfig.DOMAIN_IMAGE_LIST
+    client.download_image(f'https://{random_image_domain}/media/albums/416130.jpg', './a.jpg')
+    
 
 # 多线程发起请求
 multi_thread_launcher(

--- a/src/jmcomic/__init__.py
+++ b/src/jmcomic/__init__.py
@@ -2,7 +2,7 @@
 # 被依赖方 <--- 使用方
 # config <--- entity <--- toolkit <--- client <--- option <--- downloader
 
-__version__ = '2.5.24'
+__version__ = '2.5.25'
 
 from .api import *
 from .jm_plugin import *

--- a/src/jmcomic/jm_client_interface.py
+++ b/src/jmcomic/jm_client_interface.py
@@ -63,7 +63,7 @@ class JmImageResp(JmResp):
                     ):
         img_url = img_url or self.url
 
-        if decode_image is False:
+        if decode_image is False or scramble_id is None:
             # 不解密图片，直接保存文件
             JmImageTool.save_resp_img(
                 self,
@@ -245,9 +245,6 @@ class JmImageClient:
         :param scramble_id: 图片所在photo的scramble_id
         :param decode_image: 要保存的是解密后的图还是原图
         """
-        if scramble_id is None:
-            scramble_id = JmMagicConstants.SCRAMBLE_220980
-
         # 请求图片
         resp = self.get_jm_image(img_url)
 

--- a/src/jmcomic/jm_toolkit.py
+++ b/src/jmcomic/jm_toolkit.py
@@ -6,7 +6,7 @@ from .jm_exception import *
 class JmcomicText:
     pattern_jm_domain = compile(r'https://([\w.-]+)')
     pattern_jm_pa_id = [
-        (compile(r'(photos?|album)/(\d+)'), 2),
+        (compile(r'(photos?|albums?)/(\d+)'), 2),
         (compile(r'id=(\d+)'), 1),
     ]
     pattern_html_jm_pub_domain = compile(r'[\w-]+\.\w+/?\w+')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded documentation for downloading images, including methods for individual image downloads.
- **Bug Fixes**
	- Improved logic for image decoding based on the presence of `scramble_id`.
	- Updated regex pattern to match both singular and plural album paths.
- **Chores**
	- Version updated from 2.5.24 to 2.5.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->