### PR TITLE
v2.5.33: 更新禁漫API域名

### DIFF
--- a/src/jmcomic/__init__.py
+++ b/src/jmcomic/__init__.py
@@ -2,7 +2,7 @@
 # 被依赖方 <--- 使用方
 # config <--- entity <--- toolkit <--- client <--- option <--- downloader
 
-__version__ = '2.5.32'
+__version__ = '2.5.33'
 
 from .api import *
 from .jm_plugin import *

--- a/src/jmcomic/jm_config.py
+++ b/src/jmcomic/jm_config.py
@@ -76,7 +76,7 @@ class JmMagicConstants:
     APP_TOKEN_SECRET = '18comicAPP'
     APP_TOKEN_SECRET_2 = '18comicAPPContent'
     APP_DATA_SECRET = '185Hcomic3PAPP7R'
-    APP_VERSION = '1.7.8'
+    APP_VERSION = '1.7.9'
 
 
 # 模块级别共用配置
@@ -127,10 +127,10 @@ class JmModuleConfig:
 
     # 移动端API域名
     DOMAIN_API_LIST = shuffled('''
-    www.jmapiproxyxxx.vip
-    www.cdnblackmyth.vip
-    www.cdnblackmyth.xyz
-    www.cdnxxx-proxy.co
+    www.cdnmhwscc.vip
+    www.cdnblackmyth.club
+    www.cdnmhws.cc
+    www.cdnuc.vip
     ''')
 
     APP_HEADERS_TEMPLATE = {

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -319,7 +319,7 @@ class ZipPlugin(JmOptionPlugin):
         return (
             downloader.download_success_dict[album]
             if album is not None  # after_album
-            else downloader.download_success_dict[photo.from_album]  # after_photo
+            else downloader.download_success_dict[photo.from_album] # after_photo
         )
 
     def zip_photo(self, photo, image_list: list, zip_path: str, path_to_delete):

--- a/src/jmcomic/jm_toolkit.py
+++ b/src/jmcomic/jm_toolkit.py
@@ -317,7 +317,7 @@ class JmcomicText:
     @classmethod
     def to_zh_cn(cls, s):
         import zhconv
-        return zhconv.convert(s, 'zh_cn')
+        return zhconv.convert(s, 'zh-cn')
 
     @classmethod
     def try_mkdir(cls, save_dir: str):

--- a/tests/test_jmcomic/test_jm_client.py
+++ b/tests/test_jmcomic/test_jm_client.py
@@ -55,7 +55,10 @@ class Test_Client(JmTestConfigurable):
         ]
 
         for pair in ans:
-            self.assertListEqual(pair[0][0:9], pair[1][0:9])
+            left = pair[0][0:9]
+            right = pair[1][0:9]
+            for i, ans in enumerate(right):
+                self.assertEqual(JmcomicText.to_zh_cn(left[i]), JmcomicText.to_zh_cn(ans))
 
     def test_photo_sort(self):
         client = self.option.build_jm_client()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Application version updated to 2.5.33.
	- External service endpoints have been refreshed with new domains for improved connectivity.
- **Bug Fixes**
	- Adjusted the argument format for Chinese language conversion to enhance accuracy.
- **Tests**
	- Improved assertion logic in unit tests for more precise comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->