### PR TITLE
修复 API 响应 JSON 解析失败（处理无关数据污染）

### DIFF
--- a/src/jmcomic/jm_client_interface.py
+++ b/src/jmcomic/jm_client_interface.py
@@ -101,6 +101,17 @@ class JmApiResp(JmJsonResp):
         super().__init__(resp)
         self.ts = ts
 
+    # 重写json()方法，专门处理API响应的清理
+    @field_cache()
+    def json(self) -> Dict:
+        from .jm_toolkit import safe_parse_json  # 导入清理函数
+        try:
+            # 仅对API响应进行清理（保留原始JmJsonResp的逻辑不变）
+            clean_text = safe_parse_json(self.resp.text)
+            return clean_text
+        except Exception as e:
+            ExceptionTool.raises_resp(f'API json解析失败: {e}', self, JsonResolveFailException)
+            
     @property
     def is_success(self) -> bool:
         return super().is_success and self.json()['code'] == 200


### PR DESCRIPTION
部分 API 响应存在「有效 JSON 数据 + 无关日志 / 冗余内容」的混合格式（例如响应尾部追加服务器日志），导致 JmApiResp 在解析时抛出 JsonResolveFailException。

本次修改仅针对 API 响应的解析逻辑，做了以下调整：

1.  在 JmApiResp 中重写 json() 方法，使用 safe_parse_json 函数清理响应文本，提取并保留有效的 JSON 部分。
2. 异常信息中补充「API」标识，便于区分 API 与网页端解析错误。
3. 未改动 JmHtmlClient 及其他类的逻辑，确保网页端解析不受影响。


感谢指导！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of API response handling by safely parsing and sanitizing JSON.
  * Prevents crashes when the API returns malformed or unexpected data.
  * Provides clearer error messages on parsing failures while preserving existing success checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->