### PR TITLE
v2.6.17: 修复 download_cover 插件不兼容 download_photo 的问题 （fix #523）

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pycryptodome
 requests
 plugin_jm_server
 zhconv
+img2pdf

--- a/src/jmcomic/__init__.py
+++ b/src/jmcomic/__init__.py
@@ -2,7 +2,7 @@
 # 被依赖方 <--- 使用方
 # config <--- entity <--- toolkit <--- client <--- option <--- downloader
 
-__version__ = '2.6.16'
+__version__ = '2.6.17'
 
 from .api import *
 from .jm_plugin import *

--- a/src/jmcomic/jm_config.py
+++ b/src/jmcomic/jm_config.py
@@ -102,7 +102,7 @@ class JmMagicConstants:
     APP_TOKEN_SECRET_2 = '18comicAPPContent'
     APP_DATA_SECRET = '185Hcomic3PAPP7R'
     API_DOMAIN_SERVER_SECRET = 'diosfjckwpqpdfjkvnqQjsik'
-    APP_VERSION = '2.0.18'
+    APP_VERSION = '2.0.19'
 
 
 # 模块级别共用配置
@@ -405,8 +405,8 @@ class JmModuleConfig:
         return ts, token, tokenparam
 
     @classmethod
-    def jm_log(cls, topic: str, msg: str, e: Exception = None):
-        if cls.FLAG_ENABLE_JM_LOG is True:
+    def jm_log(cls, topic: str, msg, e: Exception = None):
+        if cls.FLAG_ENABLE_JM_LOG:
             executor = cls.EXECUTOR_LOG
             if e is None:
                 executor(topic, msg)
@@ -440,7 +440,7 @@ class JmModuleConfig:
 
         from common import Postmans
 
-        if session is True:
+        if session:
             return Postmans.new_session(**kwargs)
 
         return Postmans.new_postman(**kwargs)

--- a/src/jmcomic/jm_option.py
+++ b/src/jmcomic/jm_option.py
@@ -298,7 +298,7 @@ class JmOption:
 
         # log
         log = dic.pop('log', True)
-        if not log:
+        if log is False:
             disable_jm_log()
 
         # version

--- a/src/jmcomic/jm_option.py
+++ b/src/jmcomic/jm_option.py
@@ -298,7 +298,7 @@ class JmOption:
 
         # log
         log = dic.pop('log', True)
-        if log is False:
+        if not log:
             disable_jm_log()
 
         # version
@@ -522,7 +522,7 @@ class JmOption:
 
     # 下面的方法为调用插件提供支持
 
-    def call_all_plugin(self, group: str, safe=True, **extra):
+    def call_all_plugin(self, group: str, safe=None, **extra):
         plugin_list: List[dict] = self.plugins.get(group, [])
         if plugin_list is None or len(plugin_list) == 0:
             return
@@ -540,7 +540,7 @@ class JmOption:
             try:
                 self.invoke_plugin(pclass, kwargs, extra, pinfo)
             except BaseException as e:
-                if safe is True:
+                if safe is True or pinfo.get('safe', True):
                     jm_log('plugin.exception', e)
                 else:
                     raise e

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -125,6 +125,8 @@ class JmOptionPlugin:
         """
         if album is None:
             album = photo.from_album
+        if album is None:
+            jm_log('plugin', f'Warning: album context is None for photo={photo.photo_id}, dir_rule placeholders may fail')
         filepath: str
         base_dir: str
         if dir_rule_dict is not None:

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -36,7 +36,7 @@ class JmOptionPlugin:
         return cls(option)
 
     def log(self, msg, topic=None):
-        if self.log_enable is not True:
+        if self.log_enable:
             return
 
         jm_log(
@@ -68,7 +68,7 @@ class JmOptionPlugin:
         删除文件和文件夹
         :param paths: 路径列表
         """
-        if self.delete_original_file is not True:
+        if self.delete_original_file:
             return
 
         for p in paths:
@@ -120,7 +120,11 @@ class JmOptionPlugin:
         参数 dir_rule_dict 优先级最高，
         如果 dir_rule_dict 不为空，优先用 dir_rule_dict
         否则使用 base_dir + filename_rule + suffix
+
+        当album为空时，自动复制为photo.from_album，防止底层dir_rule的dsl包含Axx报错
         """
+        if album is None:
+            album = photo.from_album
         filepath: str
         base_dir: str
         if dir_rule_dict is not None:
@@ -248,7 +252,7 @@ class UsageLogPlugin(JmOptionPlugin):
             ])
             self.log(msg, topic='log')
 
-            if enable_warning is True:
+            if enable_warning:
                 # 警告
                 warning()
 
@@ -776,7 +780,10 @@ class Img2pdfPlugin(JmOptionPlugin):
         pdf_filepath = self.decide_filepath(album, photo, filename_rule, 'pdf', pdf_dir, dir_rule)
 
         # 调用 img2pdf 把 photo_dir 下的所有图片转为pdf
-        img_path_ls, img_dir_ls = self.write_img_2_pdf(pdf_filepath, album, photo, encrypt)
+        result = self.write_img_2_pdf(pdf_filepath, album, photo, encrypt)
+        if not result:
+            return
+        img_path_ls, img_dir_ls = result
         self.log(f'Convert Successfully: JM{album or photo} → {pdf_filepath}')
 
         # 执行删除
@@ -801,6 +808,7 @@ class Img2pdfPlugin(JmOptionPlugin):
 
         if len(img_path_ls) == 0:
             self.log(f'所有文件夹都不存在图片，无法生成pdf：{img_dir_ls}', 'error')
+            return
 
         with open(pdf_filepath, 'wb') as f:
             f.write(img2pdf.convert(img_path_ls))
@@ -851,12 +859,14 @@ class LongImgPlugin(JmOptionPlugin):
 
         # 调用 PIL 把 photo_dir 下的所有图片合并为长图
         img_path_ls = self.write_img_2_long_img(long_img_path, album, photo)
+        if not img_path_ls:
+            return
         self.log(f'Convert Successfully: JM{album or photo} → {long_img_path}')
 
         # 执行删除
         self.execute_deletion(img_path_ls)
 
-    def write_img_2_long_img(self, long_img_path, album: JmAlbumDetail, photo: JmPhotoDetail) -> List[str]:
+    def write_img_2_long_img(self, long_img_path, album: JmAlbumDetail, photo: JmPhotoDetail) -> Optional[List[str]]:
         import itertools
         from PIL import Image
 
@@ -867,6 +877,10 @@ class LongImgPlugin(JmOptionPlugin):
 
         img_paths = itertools.chain(*map(files_of_dir, img_dir_items))
         img_paths = list(filter(lambda x: not x.startswith('.'), img_paths))  # 过滤系统文件
+
+        if not img_paths:
+            self.log(f'所有文件夹都不存在图片，无法生成long_img：{img_paths}', 'error')
+            return
 
         images = self.open_images(img_paths)
 
@@ -954,11 +968,11 @@ class JmServerPlugin(JmOptionPlugin):
             base_run_kwargs.update(run)
             run = base_run_kwargs
 
-        if self.running is True:
+        if self.running:
             return
 
         with self.run_server_lock:
-            if self.running is True:
+            if self.running:
                 return
 
             # 服务器的代码位于一个独立库：plugin_jm_server，需要独立安装
@@ -1074,7 +1088,7 @@ class SubscribeAlbumUpdatePlugin(JmOptionPlugin):
                 self.log('Exception happened: ' + str(e), 'check_update.error')
                 continue
 
-            if has_update is False:
+            if not has_update:
                 continue
 
             self.log(f'album={album_id}，发现新章节: {photo_new_list}，准备开始下载')

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -68,7 +68,7 @@ class JmOptionPlugin:
         删除文件和文件夹
         :param paths: 路径列表
         """
-        if self.delete_original_file:
+        if not self.delete_original_file:
             return
 
         for p in paths:

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -125,8 +125,6 @@ class JmOptionPlugin:
         """
         if album is None:
             album = photo.from_album
-        if album is None:
-            jm_log('plugin', f'Warning: album context is None for photo={photo.photo_id}, dir_rule placeholders may fail')
         filepath: str
         base_dir: str
         if dir_rule_dict is not None:

--- a/tests/test_jmcomic/test_jm_custom.py
+++ b/tests/test_jmcomic/test_jm_custom.py
@@ -36,6 +36,8 @@ class Test_Custom(JmTestConfigurable):
             os.path.abspath(save_dir),
             os.path.abspath(base_dir + dic[1] + '/' + dic[2]),
         )
+        JmModuleConfig.CLASS_ALBUM = JmAlbumDetail
+        JmModuleConfig.CLASS_PHOTO = JmPhotoDetail
 
     def test_extends_api_client(self):
         class MyClient(JmApiClient):

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -1,0 +1,37 @@
+from test_jmcomic import *
+
+
+class Test_Plugin(JmTestConfigurable):
+
+    def test_plugin_missing_album_context(self):
+        """
+        source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/523
+
+        测试当仅下载单章(photo)时，如果上下文中缺少 album 对象，
+        各个包含路径生成的插件(如 download_cover, img2pdf, long_img, zip)
+        是否能正确从 photo.from_album 中提取专辑属性，
+        避免解析需要 {Atitle} 等本子级占位符时报错 KeyError。
+        """
+        photo_id = '350234'
+        option = self.new_option()
+
+        flawed_rule = {
+            'base_dir': option.dir_rule.base_dir,
+            'rule': '{Atitle}/{Aid}_photo.jpg'
+        }
+
+        from jmcomic.jm_downloader import DoNotDownloadImage
+
+        # 将四个需要校验的插件全部进行孤立测试，避免前一个插件后续报错导致循环终端
+        test_plugins = ['download_cover', 'img2pdf', 'long_img', 'zip']
+        option.plugins['before_photo'] = [
+            {
+                'plugin': plugin_key,
+                'kwargs': {'dir_rule': flawed_rule},
+                'safe': False  # 防止内部catch异常
+            }
+            for plugin_key in test_plugins
+        ]
+
+        download_photo(photo_id, option, downloader=DoNotDownloadImage)
+        print('✅ All folder rule plugins assert completed safely without KeyError.')

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -12,6 +12,7 @@ class Test_Plugin(JmTestConfigurable):
         是否能正确从 photo.from_album 中提取专辑属性，
         避免解析需要 {Atitle} 等本子级占位符时报错 KeyError。
         """
+        photo_id = '350234'
         option = self.new_option()
 
         flawed_rule = {
@@ -19,27 +20,18 @@ class Test_Plugin(JmTestConfigurable):
             'rule': '{Atitle}/{Aid}_photo.jpg'
         }
 
-        # 构建本地 fixture，打断真实网络与 API 下载依赖
-        album = JmAlbumDetail('111', '', None, {'id': '111', 'title': 'TestAlbum'})
-        photo_with_album = JmPhotoDetail('222', '', None, {'id': '222', 'title': 'TestPhoto'})
-        photo_with_album.from_album = album
+        from jmcomic.jm_downloader import DoNotDownloadImage
 
+        # 将四个需要校验的插件全部进行孤立测试，避免前一个插件后续报错导致循环终端
         test_plugins = ['download_cover', 'img2pdf', 'long_img', 'zip']
+        option.plugins['before_photo'] = [
+            {
+                'plugin': plugin_key,
+                'kwargs': {'dir_rule': flawed_rule},
+                'safe': False  # 防止内部catch异常
+            }
+            for plugin_key in test_plugins
+        ]
 
-        for plugin_key in test_plugins:
-            plugin_class = option.plugin_dict.get(plugin_key)
-            if not plugin_class:
-                continue
-
-            # 实例化
-            plugin: JmOptionPlugin = plugin_class(option)
-
-            # 孤立测试路径解析，绕过外部 optional dependencies (如 img2pdf, Pillow) 的阻扰
-            try:
-                # 传入 album=None，预期插件内部提取 photo_with_album 的 from_album 并在路径中成功解析 TestAlbum
-                filepath = plugin.decide_filepath(None, photo_with_album, '{Atitle}', '.jpg', None, flawed_rule)
-                self.assertIn('TestAlbum', filepath, f"Plugin {plugin_key} Failed to resolve Atitle.")
-            except KeyError as e:
-                self.fail(f"Plugin {plugin_key} Failed to populate album from photo object: {e}")
-
-        print('✅ All folder rule plugins passed self-contained path generation tests without dependency requirements.')
+        download_photo(photo_id, option, downloader=DoNotDownloadImage)
+        print('✅ All folder rule plugins assert completed safely without KeyError.')

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -12,7 +12,6 @@ class Test_Plugin(JmTestConfigurable):
         是否能正确从 photo.from_album 中提取专辑属性，
         避免解析需要 {Atitle} 等本子级占位符时报错 KeyError。
         """
-        photo_id = '350234'
         option = self.new_option()
 
         flawed_rule = {
@@ -20,18 +19,27 @@ class Test_Plugin(JmTestConfigurable):
             'rule': '{Atitle}/{Aid}_photo.jpg'
         }
 
-        from jmcomic.jm_downloader import DoNotDownloadImage
+        # 构建本地 fixture，打断真实网络与 API 下载依赖
+        album = JmAlbumDetail('111', '', None, {'id': '111', 'title': 'TestAlbum'})
+        photo_with_album = JmPhotoDetail('222', '', None, {'id': '222', 'title': 'TestPhoto'})
+        photo_with_album.from_album = album
 
-        # 将四个需要校验的插件全部进行孤立测试，避免前一个插件后续报错导致循环终端
         test_plugins = ['download_cover', 'img2pdf', 'long_img', 'zip']
-        option.plugins['before_photo'] = [
-            {
-                'plugin': plugin_key,
-                'kwargs': {'dir_rule': flawed_rule},
-                'safe': False  # 防止内部catch异常
-            }
-            for plugin_key in test_plugins
-        ]
 
-        download_photo(photo_id, option, downloader=DoNotDownloadImage)
-        print('✅ All folder rule plugins assert completed safely without KeyError.')
+        for plugin_key in test_plugins:
+            plugin_class = option.plugin_dict.get(plugin_key)
+            if not plugin_class:
+                continue
+
+            # 实例化
+            plugin: JmOptionPlugin = plugin_class(option)
+
+            # 孤立测试路径解析，绕过外部 optional dependencies (如 img2pdf, Pillow) 的阻扰
+            try:
+                # 传入 album=None，预期插件内部提取 photo_with_album 的 from_album 并在路径中成功解析 TestAlbum
+                filepath = plugin.decide_filepath(None, photo_with_album, '{Atitle}', '.jpg', None, flawed_rule)
+                self.assertIn('TestAlbum', filepath, f"Plugin {plugin_key} Failed to resolve Atitle.")
+            except KeyError as e:
+                self.fail(f"Plugin {plugin_key} Failed to populate album from photo object: {e}")
+
+        print('✅ All folder rule plugins passed self-contained path generation tests without dependency requirements.')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented folder-path errors when album info is missing; added early exits when no images are found and improved plugin failure handling to avoid crashes.

* **Refactor**
  * Streamlined boolean/truthiness checks and adjusted plugin exception-safety behavior and logging toggle semantics for more consistent control flow.

* **Chores**
  * Bumped module and app versions; added a development dependency for image-to-PDF processing.

* **Tests**
  * Added a test for missing-album plugin behavior and fixed test cleanup to restore config state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->