### PR TITLE
v2.6.18: 修复 Linux 环境下全新安装时缺失 jmv 命令的问题 (#527); 增加环境变量集成校验

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Documentation = "https://jmcomic.readthedocs.io"
 
 [project.scripts]
 jmcomic = "jmcomic.cl:main"
+jmv = "jmcomic.cl:view_main"
 
 [tool.setuptools.dynamic]
 version = {attr = "jmcomic.__version__"}

--- a/src/jmcomic/__init__.py
+++ b/src/jmcomic/__init__.py
@@ -2,7 +2,7 @@
 # 被依赖方 <--- 使用方
 # config <--- entity <--- toolkit <--- client <--- option <--- downloader
 
-__version__ = '2.6.17'
+__version__ = '2.6.18'
 
 from .api import *
 from .jm_plugin import *

--- a/tests/test_jmcomic/test_jm_cli.py
+++ b/tests/test_jmcomic/test_jm_cli.py
@@ -43,6 +43,23 @@ class Test_Cli(JmTestConfigurable):
 
     # ========== jmv 命令测试 ==========
 
+    def test_entry_points_installed(self):
+        """验证控制台命令行是否被正确安装到了所在系统的环境变量里"""
+        import shutil
+        import subprocess
+        for cmd in ['jmcomic', 'jmv']:
+            self.assertIsNotNone(
+                shutil.which(cmd),
+                f"Command '{cmd}' not found in PATH. Please verify entry_points in setup.py or [project.scripts] in pyproject.toml and ensure the package is installed."
+            )
+
+            try:
+                subprocess.run([cmd, "--help"], capture_output=True, text=True, check=True)
+            except subprocess.CalledProcessError as e:
+                self.fail(f"Command '{cmd} --help' failed with exit code {e.returncode}. Stderr: {e.stderr.strip()}")
+            except Exception as e:
+                self.fail(f"Failed to execute command '{cmd}': {e}")
+
     # -- extract_album_id --
 
     def test_jmv_extract_pure_digits(self):

--- a/tests/test_jmcomic/test_jm_cli.py
+++ b/tests/test_jmcomic/test_jm_cli.py
@@ -54,10 +54,18 @@ class Test_Cli(JmTestConfigurable):
             )
 
             try:
-                subprocess.run([cmd, "--help"], capture_output=True, text=True, check=True)
+                subprocess.run(
+                    [cmd, "--help"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=10,
+                )
+            except subprocess.TimeoutExpired:
+                self.fail(f"Command '{cmd} --help' timed out execution.")
             except subprocess.CalledProcessError as e:
                 self.fail(f"Command '{cmd} --help' failed with exit code {e.returncode}. Stderr: {e.stderr.strip()}")
-            except Exception as e:
+            except OSError as e:
                 self.fail(f"Failed to execute command '{cmd}': {e}")
 
     # -- extract_album_id --


### PR DESCRIPTION
此 PR 解决了因 `pyproject.toml` 缺乏对应的 entry points 声明，导致在全新环境（如 Linux 下从 PyPI 安装时）未生成 `jmv` 命令行可执行文件文件的问题。

**改动内容：**
- 在 `pyproject.toml` 中的 `[project.scripts]` 段补齐 `jmv = "jmcomic.cl:view_main"`。
- 在 `tests/test_jmcomic/test_jm_cli.py` 内部补充基于 `shutil.which` 和 `subprocess.run` 验证系统命令的冒烟测试断言，从根本上防止漏配问题。
- `__version__` 升级至 `2.6.18`，准备发版。

Fixes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `jmv` console command as an additional entry point alongside the existing `jmcomic` command.

* **Tests**
  * Added a test that verifies console commands are installed and discoverable, and that they respond to `--help` successfully.

* **Chores**
  * Package version bumped to 2.6.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->