### PR TITLE
feat: 优化 GitHub Actions 合并 PDF 时的文件名生成规则 (#91)

### DIFF
--- a/.github/workflows/download_dispatch.yml
+++ b/.github/workflows/download_dispatch.yml
@@ -40,6 +40,12 @@ on:
           - 是 | 本子维度合并pdf
           - 是 | 章节维度合并pdf
 
+      PDF_NAME_RULE:
+        type: string
+        description: PDF输出的文件名规则。默认本子维度的为'Atitle'，章节维度的为'Atitle_Ptitle'
+        default: ''
+        required: false
+
       ZIP_NAME:
         type: string
         default: 本子.tar.gz
@@ -78,6 +84,7 @@ jobs:
       UPLOAD_NAME: ${{ github.event.inputs.UPLOAD_NAME }}
       IMAGE_SUFFIX: ${{ github.event.inputs.IMAGE_SUFFIX }}
       PDF_OPTION: ${{ github.event.inputs.PDF_OPTION }}
+      PDF_NAME_RULE: ${{ github.event.inputs.PDF_NAME_RULE }}
 
       # 登录相关secrets
       JM_USERNAME: ${{ secrets.JM_USERNAME }}

--- a/usage/workflow_download.py
+++ b/usage/workflow_download.py
@@ -84,11 +84,16 @@ def cover_option_config(option: JmOption):
     pdf_option = env('PDF_OPTION', None)
     if pdf_option and pdf_option != '否':
         call_when = 'after_album' if pdf_option == '是 | 本子维度合并pdf' else 'after_photo'
+        
+        pdf_name_rule = env('PDF_NAME_RULE', None)
+        if not pdf_name_rule:
+            pdf_name_rule = 'Atitle' if call_when == 'after_album' else 'Atitle_Ptitle'
+            
         plugin = [{
             'plugin': Img2pdfPlugin.plugin_key,
             'kwargs': {
                 'pdf_dir': option.dir_rule.base_dir + '/pdf/',
-                'filename_rule': call_when[6].upper() + 'id',
+                'filename_rule': pdf_name_rule,
                 'delete_original_file': True,
             }
         }]


### PR DESCRIPTION
修复并优化了 GitHub Actions 工作流在启用 PDF 合并时的行为：

原本在使用 Actions 进行本子下载并导出 PDF 时，`filename_rule` 被强编码映射为 `Aid` 或 `Pid`，导致最后生成的 PDF 文件名都是数字。

此 PR 进行了以下修改：
- 将默认文件命名规则变为更人性化的形式：
  - “本子维度合并pdf”下的默认文件名为 `Atitle`
  - “章节维度合并pdf”下的默认文件名为 `Atitle_Ptitle`
- 通过在 `download_dispatch.yml` 中新增选项 `PDF_NAME_RULE`，将该设定暴露在 Actions 面板，允许用户自定义基于自身偏好的 PDF 文件命名规则。

参考 Issue：#91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable PDF output filename rule to control how generated PDFs are named based on merge mode (book/section), providing enhanced flexibility in PDF generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->