### PR TITLE
feat: 优化 GitHub Actions 合并 PDF 时的文件名生成规则

### DIFF
--- a/.github/workflows/download_dispatch.yml
+++ b/.github/workflows/download_dispatch.yml
@@ -40,6 +40,12 @@ on:
           - 是 | 本子维度合并pdf
           - 是 | 章节维度合并pdf
 
+      PDF_NAME_RULE:
+        type: string
+        description: PDF输出的文件名规则。默认本子维度的为'[{Aid}] {Atitle}'，章节维度的为'[{Aid}] {Pindex}_{Pid}_{Ptitle}'
+        default: ''
+        required: false
+
       ZIP_NAME:
         type: string
         default: 本子.tar.gz
@@ -78,6 +84,7 @@ jobs:
       UPLOAD_NAME: ${{ github.event.inputs.UPLOAD_NAME }}
       IMAGE_SUFFIX: ${{ github.event.inputs.IMAGE_SUFFIX }}
       PDF_OPTION: ${{ github.event.inputs.PDF_OPTION }}
+      PDF_NAME_RULE: ${{ github.event.inputs.PDF_NAME_RULE }}
 
       # 登录相关secrets
       JM_USERNAME: ${{ secrets.JM_USERNAME }}

--- a/usage/workflow_download.py
+++ b/usage/workflow_download.py
@@ -84,11 +84,16 @@ def cover_option_config(option: JmOption):
     pdf_option = env('PDF_OPTION', None)
     if pdf_option and pdf_option != '否':
         call_when = 'after_album' if pdf_option == '是 | 本子维度合并pdf' else 'after_photo'
+        
+        pdf_name_rule = env('PDF_NAME_RULE', None)
+        if not pdf_name_rule:
+            pdf_name_rule = '[{Aid}] {Atitle}' if call_when == 'after_album' else '[{Aid}] {Pindex}_{Pid}_{Ptitle}'
+            
         plugin = [{
             'plugin': Img2pdfPlugin.plugin_key,
             'kwargs': {
                 'pdf_dir': option.dir_rule.base_dir + '/pdf/',
-                'filename_rule': call_when[6].upper() + 'id',
+                'filename_rule': pdf_name_rule,
                 'delete_original_file': True,
             }
         }]


### PR DESCRIPTION
原来使用简单的 `Aid` 或 `Pid` 进行命名，用户反馈导出的 PDF 名字全是数字看不出是什么。现在：

1. 默认情况下，本子维度的 PDF 命名为 `Atitle`，章节维度的 PDF 命名为 `Atitle_Ptitle`。

2. 新增可选的环境变量和 Action 面板输入参数 `PDF_NAME_RULE`，允许用户自定义生成规则。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable PDF filename naming rule option to workflow dispatch with sensible defaults for different merge strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->