### PR TITLE
feat: 优化 PDF 命名规则并修正自动关闭逻辑 (#91)

### DIFF
--- a/.github/workflows/close_specific_pr.yml
+++ b/.github/workflows/close_specific_pr.yml
@@ -26,6 +26,13 @@ jobs:
         run: |
           PR_TITLE=$(jq -r ".pull_request.title" $GITHUB_EVENT_PATH)
           echo "PR_TITLE: $PR_TITLE"
+          
+          # 检查标题是否符合 Conventional Commits 格式中的 feat 或 fix (不区分大小写)
+          if printf '%s\n' "$PR_TITLE" | grep -Eiq '(^|[[:space:]])(feat|fix)(\([^)]+\))?(!)?:'; then
+            echo "PR title contains feat or fix, skipping auto-close."
+            exit 0
+          fi
+          
           gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body '${{ env.comment }}'
           gh pr close ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
         env:

--- a/.github/workflows/download_dispatch.yml
+++ b/.github/workflows/download_dispatch.yml
@@ -40,6 +40,12 @@ on:
           - 是 | 本子维度合并pdf
           - 是 | 章节维度合并pdf
 
+      PDF_NAME_RULE:
+        type: string
+        description: 'PDF文件命名规则。支持字段如 Aid, Atitle, Pindex, Pid, Ptitle'
+        default: ''
+        required: false
+
       ZIP_NAME:
         type: string
         default: 本子.tar.gz
@@ -78,6 +84,7 @@ jobs:
       UPLOAD_NAME: ${{ github.event.inputs.UPLOAD_NAME }}
       IMAGE_SUFFIX: ${{ github.event.inputs.IMAGE_SUFFIX }}
       PDF_OPTION: ${{ github.event.inputs.PDF_OPTION }}
+      PDF_NAME_RULE: ${{ github.event.inputs.PDF_NAME_RULE }}
 
       # 登录相关secrets
       JM_USERNAME: ${{ secrets.JM_USERNAME }}

--- a/usage/workflow_download.py
+++ b/usage/workflow_download.py
@@ -84,11 +84,19 @@ def cover_option_config(option: JmOption):
     pdf_option = env('PDF_OPTION', None)
     if pdf_option and pdf_option != '否':
         call_when = 'after_album' if pdf_option == '是 | 本子维度合并pdf' else 'after_photo'
+        
+        pdf_name_rule = env('PDF_NAME_RULE', None)
+        if isinstance(pdf_name_rule, str):
+            pdf_name_rule = pdf_name_rule.strip()
+            
+        if not pdf_name_rule:
+            pdf_name_rule = '[JM{Aid}] {Atitle}' if call_when == 'after_album' else '[JM{Aid}] 第{Pindex}章-JM{Pid}-{Ptitle}'
+            
         plugin = [{
             'plugin': Img2pdfPlugin.plugin_key,
             'kwargs': {
                 'pdf_dir': option.dir_rule.base_dir + '/pdf/',
-                'filename_rule': call_when[6].upper() + 'id',
+                'filename_rule': pdf_name_rule,
                 'delete_original_file': True,
             }
         }]


### PR DESCRIPTION
此次 PR 旨在解决用户反馈的 PDF 文件名难以辨认以及自动关闭逻辑误伤开发 PR 的问题。

### 主要改动：

1.  **优化 PDF 文件命名默认规则**：
    *   **本子维度**：默认使用 `[JM{Aid}] {Atitle}`，包含项目前缀、ID 和本子标题。
    *   **章节维度**：默认使用 `[JM{Aid}] 第{Pindex}章-JM{Pid}-{Ptitle}`，提供详细的层级信息。
2.  **增强 Actions 灵活性**：
    *   在 `download_dispatch.yml` 中新增 `PDF_NAME_RULE` 选项，支持用户根据需求自定义命名规则。
3.  **修复 `close_specific_pr.yml` 误伤逻辑**：
    *   增加了对 PR 标题的检查。如果标题包含 `feat:` 或 `fix:`，则会自动跳过关闭逻辑，允许有意义的特性或修复 PR 正常开启。

关联 Issue: #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF naming is now customizable via a manual dispatch input; provided rule is applied when generating PDFs.

* **Chores**
  * Auto-close workflow now skips closing PRs whose titles use Conventional Commits-style feat/fix prefixes (case-insensitive).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->