### PR TITLE
feat(plugin): 可选依赖提供 extras 安装项与 strict_dependencies 严格校验

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,17 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+plugins = [
+    "img2pdf",
+    "pikepdf",
+    "psutil",
+    "py7zr",
+    "pyzipper",
+    "rich",
+    "browser_cookie3",
+]
+
 [project.urls]
 Homepage = "https://github.com/hect0x7/JMComic-Crawler-Python"
 Documentation = "https://jmcomic.readthedocs.io"

--- a/src/jmcomic/jm_option.py
+++ b/src/jmcomic/jm_option.py
@@ -203,6 +203,8 @@ class JmOption:
         self.need_wait_plugins = []
 
         if call_after_init_plugin:
+            if self.plugins.src_dict.get('strict_dependencies', False):
+                self.check_plugins_dependencies()
             self.call_all_plugin('after_init', safe=True)
 
     def copy_option(self):
@@ -351,7 +353,9 @@ class JmOption:
             # 意图聚焦：建议配置中只展示相关的 zip 插件，剔除其他无关插件的干扰
             advice_plugins = {}
             for g, plist in plugins.items():
-                zips = [p for p in plist if p.get('plugin') == 'zip']
+                if not isinstance(plist, list):
+                    continue
+                zips = [p for p in plist if isinstance(p, dict) and p.get('plugin') == 'zip']
                 if zips:
                     advice_plugins[g] = zips
 
@@ -632,6 +636,52 @@ class JmOption:
         return await download_photo_async(photo_id, self, *args, **kwargs)
 
     # 下面的方法为调用插件提供支持
+
+    def check_plugins_dependencies(self) -> None:
+        """
+        校验已启用插件的可选依赖库是否安装，缺失则直接报错。
+
+        由 plugins.strict_dependencies 配置项开启，在option初始化（after_init）阶段执行，
+        让依赖问题在任务启动时就暴露，而不是等到插件静默跳过、产物缺失时才发现。
+
+        各插件通过类属性 optional_dependencies 声明所依赖的可选库（import名），
+        也可重写 required_dependencies_for(kwargs) 按插件配置返回实际需要的库
+        （如未加密的 zip 无需 pyzipper/py7zr）。
+        """
+        import importlib.util
+
+        # 保证 jm_plugin.py 被加载
+        from .jm_plugin import JmOptionPlugin
+
+        plugin_registry = JmModuleConfig.REGISTRY_PLUGIN
+        missing: Dict[str, List[str]] = {}
+
+        for group, plist in self.plugins.src_dict.items():
+            if not isinstance(plist, list):
+                continue
+
+            for pinfo in plist:
+                if not isinstance(pinfo, dict):
+                    continue
+
+                pclass: Optional[Type[JmOptionPlugin]] = plugin_registry.get(pinfo.get('plugin'), None)
+                if pclass is None:
+                    continue
+
+                for lib in pclass.required_dependencies_for(pinfo.get('kwargs') or {}):
+                    if importlib.util.find_spec(lib) is None:
+                        missing.setdefault(lib, []).append(pclass.plugin_key)
+
+        if missing:
+            detail = '; '.join(
+                f'库[{lib}] 被插件 {plugin_keys} 使用'
+                for lib, plugin_keys in sorted(missing.items())
+            )
+            ExceptionTool.raises(
+                '插件依赖校验失败（plugins.strict_dependencies = true）: '
+                f'{detail}。'
+                '请安装缺失的依赖库，或一键安装全部插件依赖: pip install jmcomic[plugins]'
+            )
 
     def call_all_plugin(self, group: str, safe=None, **extra):
         plugin_list: List[dict] = self.plugins.get(group, [])

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -344,12 +344,30 @@ class ZipPlugin(JmOptionPlugin):
 
     @classmethod
     def required_dependencies_for(cls, kwargs: dict) -> tuple:
-        encrypt = kwargs.get('encrypt')
+        encrypt = cls.check_encrypt_param(kwargs.get('encrypt'))
         if not encrypt:
             return ()
         if encrypt.get('impl', '') == '7z':
             return ('py7zr',)
         return ('pyzipper',)
+
+    @staticmethod
+    def check_encrypt_param(encrypt):
+        """
+        校验 encrypt 配置的类型，返回规范化后的值（未配置时返回 None）。
+
+        encrypt 必须是映射（如 {type: sha256, password: xxx}），
+        写成真值标量（encrypt: enabled）时后续的 encrypt.get(...) 会抛
+        AttributeError，绕过了配置校验机制、报错也难以理解，这里统一拦掉。
+        """
+        if encrypt is None:
+            return None
+        if not isinstance(encrypt, dict):
+            ExceptionTool.raises(
+                f'zip插件的encrypt参数类型有误，预期为映射（如 {{type: sha256, password: xxx}}），'
+                f'实际类型为{type(encrypt)}'
+            )
+        return encrypt
 
     # noinspection PyAttributeOutsideInit
     def invoke(self,
@@ -373,6 +391,8 @@ class ZipPlugin(JmOptionPlugin):
             level = 'album' if album is not None else 'photo'
         self.level = level
         self.delete_original_file = delete_original_file
+        # 未开启 strict_dependencies 时也拦掉非法的 encrypt 类型
+        encrypt = self.check_encrypt_param(encrypt)
 
         # 确保压缩文件所在文件夹存在
         zip_dir = JmcomicText.parse_to_abspath(zip_dir)

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -20,6 +20,20 @@ class PluginValidationException(Exception):
 
 class JmOptionPlugin:
     plugin_key: str
+    # 插件运行所需的非核心依赖库（import名）。
+    # 声明后，开启 plugins.strict_dependencies 的option会在初始化阶段统一校验。
+    optional_dependencies: tuple = ()
+
+    @classmethod
+    def required_dependencies_for(cls, kwargs: dict) -> tuple:
+        """
+        返回该插件在给定 kwargs 配置下实际需要的可选库，供 strict_dependencies 校验使用。
+
+        默认返回类声明的 optional_dependencies。
+        插件可按配置重写此方法，避免对合法配置误报
+        （如未加密的 zip 用标准库 zipfile 即可，无需 pyzipper/py7zr）。
+        """
+        return cls.optional_dependencies
 
     def __init__(self, option: JmOption):
         self.option = option
@@ -175,6 +189,7 @@ class JmLoginPlugin(JmOptionPlugin):
 
 class UsageLogPlugin(JmOptionPlugin):
     plugin_key = 'usage_log'
+    optional_dependencies = ('psutil',)
 
     def invoke(self, **kwargs) -> None:
         import threading
@@ -324,6 +339,17 @@ class ZipPlugin(JmOptionPlugin):
     """
 
     plugin_key = 'zip'
+    # zip 依赖取决于加密配置：未加密用标准库 zipfile，加密 zip 用 pyzipper，7z 用 py7zr
+    optional_dependencies = ()
+
+    @classmethod
+    def required_dependencies_for(cls, kwargs: dict) -> tuple:
+        encrypt = kwargs.get('encrypt')
+        if not encrypt:
+            return ()
+        if encrypt.get('impl', '') == '7z':
+            return ('py7zr',)
+        return ('pyzipper',)
 
     # noinspection PyAttributeOutsideInit
     def invoke(self,
@@ -927,6 +953,7 @@ class AsyncProgressDownloader(JmAsyncDownloader):
 
 class DownloadProgressPlugin(JmOptionPlugin):
     plugin_key = 'download_progress'
+    optional_dependencies = ('rich',)
     log_file = 'jmcomic-download.log'
 
     @staticmethod
@@ -1036,6 +1063,7 @@ class DownloadProgressPlugin(JmOptionPlugin):
 
 class AutoSetBrowserCookiesPlugin(JmOptionPlugin):
     plugin_key = 'auto_set_browser_cookies'
+    optional_dependencies = ('browser_cookie3',)
 
     accepted_cookies_keys = str_to_set('''
     yuo1
@@ -1211,6 +1239,14 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
 
 class Img2pdfPlugin(JmOptionPlugin):
     plugin_key = 'img2pdf'
+    # img2pdf 总是需要；pikepdf 仅在加密 pdf 时需要
+    optional_dependencies = ('img2pdf',)
+
+    @classmethod
+    def required_dependencies_for(cls, kwargs: dict) -> tuple:
+        if kwargs.get('encrypt'):
+            return cls.optional_dependencies + ('pikepdf',)
+        return cls.optional_dependencies
 
     def invoke(self,
                photo: JmPhotoDetail = None,

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -36,6 +36,107 @@ class Test_Plugin(JmTestConfigurable):
         download_photo(photo_id, option, downloader=DoNotDownloadImage)
         print('✅ All folder rule plugins assert completed safely without KeyError.')
 
+    def test_strict_dependencies(self):
+        """
+        source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/572
+
+        测试开启 plugins.strict_dependencies 后：
+        1. 启用的插件缺少依赖库时，在 option 初始化（after_init）阶段直接报错
+        2. 未开启时保持原有行为，不校验
+        """
+        from jmcomic import JmOption, JmModuleConfig, JmcomicException
+
+        # 临时给 img2pdf 插件声明一个必然不存在的依赖，保证测试不依赖运行环境装了什么库
+        pclass = JmModuleConfig.REGISTRY_PLUGIN['img2pdf']
+        origin_deps = pclass.optional_dependencies
+        pclass.optional_dependencies = ('__lib_not_exists__',)
+        try:
+            # 1) 开启 strict_dependencies，构建 option 时应直接抛异常
+            dic = {
+                'plugins': {
+                    'strict_dependencies': True,
+                    'after_album': [{'plugin': 'img2pdf'}],
+                }
+            }
+            with self.assertRaises(JmcomicException) as ctx:
+                JmOption.construct(dic)
+            self.assertIn('strict_dependencies', str(ctx.exception))
+            self.assertIn('pip install jmcomic[plugins]', str(ctx.exception))
+            print('✅ strict_dependencies on: missing lib raises at option init.')
+
+            # 2) 未开启时，不做校验，正常构建
+            dic2 = {
+                'plugins': {
+                    'after_album': [{'plugin': 'img2pdf'}],
+                }
+            }
+            option = JmOption.construct(dic2)
+            self.assertIsNotNone(option)
+            print('✅ strict_dependencies off: keeps silent as before.')
+        finally:
+            pclass.optional_dependencies = origin_deps
+
+    def test_strict_dependencies_kwargs_aware(self):
+        """
+        source: https://github.com/hect0x7/JMComic-Crawler-Python/pull/575 (CodeRabbit review)
+
+        校验应感知插件配置（required_dependencies_for），并直接测真实解析器，
+        只 mock importlib.util.find_spec 模拟库缺失，不替换解析器本身：
+        1. 未加密 zip：真实解析器返回 ()，即便 pyzipper/py7zr 缺失也不误报
+        2. 加密 zip（impl=7z）：解析器返回 py7zr，缺失时报错
+        3. 默认加密 zip：解析器返回 pyzipper，缺失时报错
+        4. img2pdf 未加密：解析器返回 (img2pdf,)，不查 pikepdf
+        5. img2pdf 加密：解析器返回 (img2pdf, pikepdf)，缺失时报错
+        """
+        import importlib.util as _iu
+        from unittest import mock
+
+        from jmcomic import JmOption, JmcomicException
+
+        real_find_spec = _iu.find_spec
+
+        def find_spec_missing(*missing):
+            def fake(name, *args, **kwargs):
+                if name in missing:
+                    return None
+                return real_find_spec(name, *args, **kwargs)
+            return fake
+
+        def build_zip(kwargs):
+            return {'plugins': {'strict_dependencies': True,
+                                'after_album': [{'plugin': 'zip', 'kwargs': kwargs}]}}
+
+        # 1) 未加密 zip：不查任何加密库
+        with mock.patch('importlib.util.find_spec', side_effect=find_spec_missing('pyzipper', 'py7zr')):
+            self.assertIsNotNone(JmOption.construct(build_zip({'zip_dir': './'})))
+        print('✅ real resolver: plain zip needs no optional lib.')
+
+        # 2) 加密 zip（impl=7z）：查 py7zr
+        with mock.patch('importlib.util.find_spec', side_effect=find_spec_missing('py7zr')):
+            with self.assertRaises(JmcomicException):
+                JmOption.construct(build_zip({'zip_dir': './', 'encrypt': {'impl': '7z'}}))
+        print('✅ real resolver: 7z zip requires py7zr.')
+
+        # 3) 默认加密 zip：查 pyzipper
+        with mock.patch('importlib.util.find_spec', side_effect=find_spec_missing('pyzipper')):
+            with self.assertRaises(JmcomicException):
+                JmOption.construct(build_zip({'zip_dir': './', 'encrypt': {'type': 'sha256'}}))
+        print('✅ real resolver: encrypted zip requires pyzipper.')
+
+        # 4) img2pdf 未加密：不查 pikepdf
+        dic4 = {'plugins': {'strict_dependencies': True,
+                            'after_album': [{'plugin': 'img2pdf'}]}}
+        with mock.patch('importlib.util.find_spec', side_effect=find_spec_missing('pikepdf')):
+            self.assertIsNotNone(JmOption.construct(dic4))
+
+        # 5) img2pdf 加密：查 pikepdf
+        dic5 = {'plugins': {'strict_dependencies': True,
+                            'after_album': [{'plugin': 'img2pdf', 'kwargs': {'encrypt': {'type': 'sha256'}}}]}}
+        with mock.patch('importlib.util.find_spec', side_effect=find_spec_missing('pikepdf')):
+            with self.assertRaises(JmcomicException):
+                JmOption.construct(dic5)
+        print('✅ real resolver: img2pdf requires pikepdf only when encrypt.')
+
     def test_calibre_metadata(self):
         """
         source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/573

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -99,6 +99,11 @@ class Test_Plugin(JmTestConfigurable):
             def fake(name, *args, **kwargs):
                 if name in missing:
                     return None
+                # img2pdf 是 img2pdf 插件的无条件依赖，未显式列入 missing 时
+                # 固定返回非 None，避免用例结果取决于运行环境装没装 img2pdf，
+                # 也让加密用例能确定性地走到 pikepdf 检查
+                if name == 'img2pdf':
+                    return object()
                 return real_find_spec(name, *args, **kwargs)
             return fake
 

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -137,6 +137,52 @@ class Test_Plugin(JmTestConfigurable):
                 JmOption.construct(dic5)
         print('✅ real resolver: img2pdf requires pikepdf only when encrypt.')
 
+    def test_strict_dependencies_rejects_non_mapping_encrypt(self):
+        """
+        source: https://github.com/hect0x7/JMComic-Crawler-Python/pull/575 (CodeRabbit review)
+
+        encrypt 必须是映射。写成真值标量（encrypt: enabled）时，之前会在
+        required_dependencies_for 里 encrypt.get(...) 抛 AttributeError，
+        报错既不是 JmcomicException、也绕过了配置校验机制。
+        现在应统一抛出可读的配置错误。
+        """
+        from jmcomic import JmOption, JmcomicException
+
+        for bad in ('enabled', True, 1):
+            dic = {'plugins': {'strict_dependencies': True,
+                               'after_album': [{'plugin': 'zip',
+                                                'kwargs': {'zip_dir': './', 'encrypt': bad}}]}}
+            # 不能是 AttributeError
+            try:
+                JmOption.construct(dic)
+            except JmcomicException as e:
+                self.assertIn('encrypt', str(e))
+            except AttributeError as e:
+                self.fail(f'encrypt={bad!r} 仍抛 AttributeError: {e}')
+            else:
+                self.fail(f'encrypt={bad!r} 应当抛配置错误，实际构建成功')
+        print('✅ non-mapping encrypt rejected with a readable config error.')
+
+        # 未开启 strict_dependencies 时，construct 阶段不校验插件配置，
+        # 但真正调用 zip 插件时应抛出可读的配置错误，而不是 AttributeError
+        from jmcomic import JmModuleConfig
+
+        zip_cls = JmModuleConfig.REGISTRY_PLUGIN['zip']
+
+        class _FakeOption:
+            pass
+
+        fake = _FakeOption()
+        try:
+            zip_cls(fake).check_encrypt_param('enabled')
+        except JmcomicException as e:
+            self.assertIn('encrypt', str(e))
+        except AttributeError as e:
+            self.fail(f'zip 插件仍抛 AttributeError: {e}')
+        else:
+            self.fail('非 mapping 的 encrypt 应当抛配置错误')
+        print('✅ non-mapping encrypt rejected instead of raising AttributeError.')
+
     def test_calibre_metadata(self):
         """
         source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/573


### PR DESCRIPTION
Closes #572

按 issue 里讨论的两个方向实现了，改动如下：

**1. extras 全家桶**

`pyproject.toml` 新增可选依赖组，一条命令装齐插件依赖：

```bash
pip install jmcomic[plugins]
```

包含 img2pdf、pikepdf、psutil、py7zr、pyzipper、rich、browser_cookie3。

**2. strict_dependencies 严格校验**

各插件类通过 `optional_dependencies` 类属性声明自己依赖的可选库（usage_log/zip/download_progress/auto_set_browser_cookies/img2pdf 这五个），然后在 `JmOption` 初始化（after_init）阶段统一预检：

```yaml
plugins:
  strict_dependencies: true
  after_album:
    - plugin: img2pdf
```

开启后，已启用插件缺依赖会在任务启动时直接报错，并提示 `pip install jmcomic[plugins]`，不再像之前那样跑到最后只留一个 warning、产物静默缺失。

**测试**

`test_strict_dependencies` 覆盖了开/关两种情况（给插件临时声明一个必然不存在的依赖来模拟缺失，不依赖运行环境），已本地跑通。

有一个点说明下：`jm_server` 插件依赖的 `jm-view-server` 是外部命令行工具，没有放进 extras 里，如果需要也可以加上。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional plugin dependency bundle for enhanced plugin functionality.
  - Added Calibre-compatible metadata generation, including optional album cover references.
  - Strict dependency validation now checks only libraries required by the selected plugin configuration.
  - Added clearer installation guidance when required plugin libraries are missing.
  - ZIP and PDF encryption settings now request only the necessary supporting libraries.

- **Bug Fixes**
  - Improved handling of plugin settings during ZIP configuration migration.

- **Tests**
  - Added coverage for configuration-aware dependency validation, encrypted archives, and PDF output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->