### PR TITLE
feat(plugin): 新增 calibre_metadata 插件，为 Calibre 用户生成 metadata.opf

### DIFF
--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -1846,3 +1846,106 @@ class DownloadCoverPlugin(JmOptionPlugin):
             self.log(f'album-{album_id}的封面已存在，跳过下载: [{save_path}]', 'skip')
             return
         downloader.client.download_album_cover(album_id, save_path, size)
+
+
+class CalibreMetadataPlugin(JmOptionPlugin):
+    """
+    功能：为本子生成 Calibre 可识别的元数据文件 metadata.opf。
+
+    通常挂在 after_album 上，每个本子在其目录下生成一份 metadata.opf，
+    Calibre 导入（从 OPF 读元数据）时可以自动带上书名、作者、标签、简介和封面。
+
+    配置示例：
+
+    ```yml
+    plugins:
+      after_album:
+        - plugin: calibre_metadata
+          kwargs:
+            dir_rule:
+              rule: "Bd/Aid/metadata.opf"
+              base_dir: "./"
+            include_cover: true
+            fields: # 追加静态字段
+              language: "zh"
+    ```
+
+    说明：
+    - identifier 固定写为 jmcomic:{album_id}，可在 Calibre 中反查回禁漫的 album_id
+    - fields 中的 title/author 可覆盖默认取值，其余键值对按 dc:{key} 写入
+    - include_cover 依赖 downloader（after_album 阶段自动传入）
+    """
+    plugin_key = 'calibre_metadata'
+
+    def invoke(self,
+               dir_rule: dict,
+               album: JmAlbumDetail = None,
+               photo: JmPhotoDetail = None,
+               downloader=None,
+               include_cover=False,
+               fields=None,
+               **kwargs) -> None:
+        from xml.sax.saxutils import escape
+
+        self.require_param(album, '本插件需在after_album阶段使用，需要album参数')
+        opf_path = self.decide_filepath(album, photo, None, None, None, dir_rule)
+        opf_dir = os.path.dirname(opf_path)
+
+        fields = dict(fields or {})
+
+        # 标题与作者，允许通过 fields 覆盖；作者为空时由 album.author 兜底为 DEFAULT_AUTHOR
+        title = str(fields.pop('title', album.title))
+        author = str(fields.pop('author', album.author))
+
+        # 封面：与 metadata.opf 同目录存放 cover.jpg，并在 OPF 中引用
+        cover_line = ''
+        manifest_line = ''
+        if include_cover:
+            cover_path = os.path.join(opf_dir, 'cover.jpg')
+            self.download_cover_if_needed(album.id, cover_path, downloader)
+            manifest_line = (
+                '  <manifest>\n'
+                '    <item id="cover-image" href="cover.jpg" media-type="image/jpeg"/>\n'
+                '  </manifest>\n'
+            )
+            cover_line = '  <meta name="cover" content="cover-image"/>\n'
+
+        subject_lines = ''.join(
+            f'  <dc:subject>{escape(str(tag))}</dc:subject>\n'
+            for tag in (album.tags or [])
+        )
+
+        extra_lines = ''.join(
+            f'  <dc:{escape(str(key))}>{escape(str(value))}</dc:{escape(str(key))}>\n'
+            for key, value in fields.items()
+        )
+
+        xml = (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            '<package version="2.0" xmlns="http://www.idpf.org/2007/opf"\n'
+            '        xmlns:dc="http://purl.org/dc/elements/1.1/"\n'
+            '        xmlns:opf="http://www.idpf.org/2007/opf">\n'
+            '  <metadata>\n'
+            f'    <dc:title>{escape(title)}</dc:title>\n'
+            f'    <dc:creator opf:role="aut">{escape(author)}</dc:creator>\n'
+            f'{subject_lines}'
+            f'    <dc:identifier opf:scheme="JMCOMIC">jmcomic:{album.id}</dc:identifier>\n'
+            f'    <dc:description>{escape(album.description)}</dc:description>\n'
+            f'{extra_lines}'
+            f'{cover_line}'
+            '  </metadata>\n'
+            f'{manifest_line}'
+            '</package>\n'
+        )
+
+        mkdir_if_not_exists(opf_dir)
+        with open(opf_path, 'w', encoding='utf-8') as f:
+            f.write(xml)
+        self.log(f'已生成Calibre元数据文件 → [{opf_path}]')
+
+    def download_cover_if_needed(self, album_id: str, cover_path: str, downloader):
+        if self.option.download.cache and os.path.exists(cover_path):
+            self.log(f'album-{album_id}的封面已存在，跳过下载: [{cover_path}]', 'skip')
+            return
+        self.require_param(downloader, 'include_cover=true时需要downloader参数（after_album阶段会自动传入）')
+        downloader.client.download_album_cover(album_id, cover_path, '')

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -1872,10 +1872,17 @@ class CalibreMetadataPlugin(JmOptionPlugin):
 
     说明：
     - identifier 固定写为 jmcomic:{album_id}，可在 Calibre 中反查回禁漫的 album_id
-    - fields 中的 title/author 可覆盖默认取值，其余键值对按 dc:{key} 写入
+    - fields 中的 title/author 可覆盖默认取值，其余键值对须为 Dublin Core 元素名（如 language/publisher/date），按 dc:{key} 写入，不支持的键会忽略并告警
     - include_cover 依赖 downloader（after_album 阶段自动传入）
     """
     plugin_key = 'calibre_metadata'
+
+    # fields 允许的 Dublin Core 元素名（核心15元素），避免非法元素名生成无效 XML
+    DUBLIN_CORE_ELEMENTS = frozenset({
+        'title', 'creator', 'subject', 'description', 'publisher', 'contributor',
+        'date', 'type', 'format', 'identifier', 'source', 'language', 'relation',
+        'coverage', 'rights',
+    })
 
     def invoke(self,
                dir_rule: dict,
@@ -1915,10 +1922,14 @@ class CalibreMetadataPlugin(JmOptionPlugin):
             for tag in (album.tags or [])
         )
 
-        extra_lines = ''.join(
-            f'  <dc:{escape(str(key))}>{escape(str(value))}</dc:{escape(str(key))}>\n'
-            for key, value in fields.items()
-        )
+        extra_lines = ''
+        for key, value in fields.items():
+            key = str(key)
+            if key not in self.DUBLIN_CORE_ELEMENTS:
+                self.log(f'calibre_metadata: 忽略不支持的fields字段 [{key}]，'
+                         f'仅支持Dublin Core元素: {", ".join(sorted(self.DUBLIN_CORE_ELEMENTS))}', 'warning')
+                continue
+            extra_lines += f'  <dc:{key}>{escape(str(value))}</dc:{key}>\n'
 
         xml = (
             '<?xml version="1.0" encoding="utf-8"?>\n'

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -35,3 +35,109 @@ class Test_Plugin(JmTestConfigurable):
 
         download_photo(photo_id, option, downloader=DoNotDownloadImage)
         print('✅ All folder rule plugins assert completed safely without KeyError.')
+
+    def test_calibre_metadata(self):
+        """
+        source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/573
+
+        测试 calibre_metadata 插件：
+        1. after_album 阶段生成 metadata.opf，包含书名/作者/标签/identifier
+        2. fields 静态字段（如 language）按维护者建议写入
+        3. 作者为空时兜底 DEFAULT_AUTHOR；XML 特殊字符正确转义
+        """
+        import tempfile
+        import shutil
+        import xml.etree.ElementTree as ET
+
+        from jmcomic import JmOption, JmModuleConfig, JmAlbumDetail
+
+        album = JmAlbumDetail(
+            album_id='123456',
+            scramble_id='220980',
+            name='测试<本子>名 & 特殊"字符"',
+            episode_list=[],
+            page_count=10,
+            pub_date='2026-01-01',
+            update_date='2026-01-02',
+            likes='1K',
+            views='2K',
+            comment_count=0,
+            works=['作品A'],
+            actors=['角色A'],
+            authors=['作者甲'],
+            tags=['tag1', '中文标签'],
+            description='简介 <b>含XML特殊字符</b>',
+        )
+
+        tmp = tempfile.mkdtemp(prefix='jm_test_calibre_')
+        try:
+            dic = {
+                'dir_rule': {'rule': 'Bd_Atitle', 'base_dir': tmp},
+                'plugins': {
+                    'after_album': [
+                        {
+                            'plugin': 'calibre_metadata',
+                            'kwargs': {
+                                'dir_rule': {
+                                    'rule': 'Bd/Atitle/metadata.opf',
+                                    'base_dir': tmp,
+                                },
+                                'fields': {'language': 'zh'},
+                            },
+                        },
+                    ],
+                },
+            }
+            option = JmOption.construct(dic)
+            option.call_all_plugin('after_album', album=album, downloader=None)
+
+            import glob
+            opf_list = glob.glob(os.path.join(tmp, '**', 'metadata.opf'), recursive=True)
+            self.assertEqual(len(opf_list), 1, f'expected 1 opf, got: {opf_list}')
+            opf_path = opf_list[0]
+
+            root = ET.parse(opf_path).getroot()
+            ns = {'dc': 'http://purl.org/dc/elements/1.1/', 'opf': 'http://www.idpf.org/2007/opf'}
+
+            self.assertEqual(root.find('.//dc:title', ns).text, album.title)
+            self.assertEqual(root.find('.//dc:creator', ns).text, '作者甲')
+            self.assertEqual(
+                [e.text for e in root.findall('.//dc:subject', ns)],
+                ['tag1', '中文标签'],
+            )
+            self.assertEqual(root.find('.//dc:identifier', ns).text, 'jmcomic:123456')
+            self.assertEqual(root.find('.//dc:language', ns).text, 'zh')
+            self.assertEqual(root.find('.//dc:description', ns).text, '简介 <b>含XML特殊字符</b>')
+            self.assertIsNone(root.find('.//{*}manifest'), 'include_cover=False 时不应有 manifest')
+            print('✅ metadata.opf generated with escaped title/tags/identifier/fields.')
+
+            # 作者为空时兜底 DEFAULT_AUTHOR
+            album2 = JmAlbumDetail(
+                album_id='654321', scramble_id='220980', name='无作者本子',
+                episode_list=[], page_count=1, pub_date='', update_date='',
+                likes='', views='', comment_count=0,
+                works=[], actors=[], authors=[], tags=[],
+            )
+            dic2 = {
+                'plugins': {
+                    'after_album': [
+                        {
+                            'plugin': 'calibre_metadata',
+                            'kwargs': {'dir_rule': {'rule': 'Bd/Aid/metadata.opf', 'base_dir': tmp}},
+                        },
+                    ],
+                },
+            }
+            option2 = JmOption.construct(dic2)
+            option2.call_all_plugin('after_album', album=album2, downloader=None)
+
+            opf2 = os.path.join(tmp, '654321', 'metadata.opf')
+            root2 = ET.parse(opf2).getroot()
+            self.assertEqual(
+                root2.find('.//dc:creator', ns).text,
+                JmModuleConfig.DEFAULT_AUTHOR,
+            )
+            self.assertEqual(root2.find('.//dc:identifier', ns).text, 'jmcomic:654321')
+            print('✅ author falls back to DEFAULT_AUTHOR when authors is empty.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -82,7 +82,7 @@ class Test_Plugin(JmTestConfigurable):
                                     'rule': 'Bd/Atitle/metadata.opf',
                                     'base_dir': tmp,
                                 },
-                                'fields': {'language': 'zh'},
+                                'fields': {'language': 'zh', 'series index': '1'},
                             },
                         },
                     ],
@@ -107,6 +107,8 @@ class Test_Plugin(JmTestConfigurable):
             )
             self.assertEqual(root.find('.//dc:identifier', ns).text, 'jmcomic:123456')
             self.assertEqual(root.find('.//dc:language', ns).text, 'zh')
+            self.assertIsNone(root.find('.//dc:series_index', ns), '非法Dublin Core元素名应被忽略')
+            self.assertIsNone(root.find('.//{"series index"}', ns))
             self.assertEqual(root.find('.//dc:description', ns).text, '简介 <b>含XML特殊字符</b>')
             self.assertIsNone(root.find('.//{*}manifest'), 'include_cover=False 时不应有 manifest')
             print('✅ metadata.opf generated with escaped title/tags/identifier/fields.')


### PR DESCRIPTION
Closes #573

按 issue 里讨论的方案实现了 `calibre_metadata` 插件，配置结构采纳了维护者建议的 `fields` 嵌套层：

```yml
plugins:
  after_album:
    - plugin: calibre_metadata
      kwargs:
        dir_rule:
          rule: "Bd/Aid/metadata.opf"
          base_dir: "./"
        include_cover: true
        fields: # 追加静态字段
          language: "zh"
```

**字段映射**

- `title` ← `album.title`，`fields.title` 可覆盖
- 作者 ← `album.author`（authors 为空时兜底 `DEFAULT_AUTHOR`，与 `favorite_folder_export` 行为一致），`fields.author` 可覆盖
- tags → `dc:subject`
- identifier 固定 `<dc:identifier opf:scheme="JMCOMIC">jmcomic:{album_id}</dc:identifier>`，Calibre 里的书可反查回禁漫 album_id
- `fields` 中其余键值对按 `dc:{key}` 写入（`language: "zh"` → `<dc:language>zh</dc:language>`）
- 简介写入 `dc:description`

**封面**

`include_cover: true` 时下载封面到 metadata.opf 同目录 `cover.jpg`，OPF 中带标准 manifest + `<meta name="cover">` 引用，Calibre 导入时直接识别。尊重 `download.cache` 配置，封面已存在则跳过。

**测试**

`test_calibre_metadata` 覆盖：OPF 生成与 XML 结构（ElementTree 解析校验）、XML 特殊字符转义、fields 静态字段、作者为空时兜底 DEFAULT_AUTHOR。已本地跑通。

一个实现细节：DSL 规则用 `Bd/Aid/metadata.opf` 这种 `/` 分隔格式（首 token 必须是单独的 `Bd`），之前我在 issue 草稿里写的 `Bd/{Atitle}/metadata.opf` 实际会被当成字面量目录名，文档里可以留意一下。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Calibre metadata export option that generates compatible OPF files with titles, authors, tags, descriptions, identifiers, and custom metadata.
  * Optionally downloads and includes album cover images alongside exported metadata.
  * Uses fallback author information when album author details are unavailable.
  * Safely skips unsupported custom metadata fields.

* **Tests**
  * Added coverage for metadata generation, custom fields, XML escaping, identifier formatting, cover handling, and author fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->