### PR TITLE
fix(plugin): 收藏夹导出失败时重试并明确报错，避免数据静默缺失

### DIFF
--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -1140,7 +1140,7 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
             if self.zip_password is None:
                 self.zip_folder_without_password(self.files, self.zip_filepath)
             else:
-                self.zip_with_password()
+                self.zip_with_password(self.files, self.zip_filepath)
 
             self.execute_deletion(self.files)
 
@@ -1248,11 +1248,27 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
             for file in files:
                 zipf.write(file, arcname=of_file_name(file))
 
-    def zip_with_password(self):
-        # 构造shell命令
+    def zip_with_password(self, files, zip_path):
+        """
+        用 7z 打包指定文件并加密。
+
+        只打包传入的 files，不打包整个 save_dir：否则会连上一轮遗留的旧导出、
+        以及失败收藏夹写了一半的 csv 一起塞进包里，而这些文件并不在
+        execute_deletion 的删除范围内，等于往产物里混入无关数据。
+
+        :param files: 要压缩的文件的绝对路径的列表
+        :param zip_path: 压缩文件的保存路径
+        """
+        import shlex
+
+        # 逐个列举待打包文件，-spf 保留绝对路径（避免依赖 cwd）
+        file_args = ' '.join(
+            shlex.quote(of_file_name(f)) for f in files
+        )
+
         cmd_list = f'''
         cd {self.save_dir}
-        7z a "{self.zip_filepath}" "./" -p{self.zip_password} -mhe=on > "../7z_output.txt"
+        7z a "{zip_path}" {file_args} -p{self.zip_password} -mhe=on > "../7z_output.txt"
         
         '''
         self.log(f'运行命令: {cmd_list}')

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -1097,13 +1097,16 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
                zip_filepath=None,
                zip_password=None,
                delete_original_file=False,
+               max_retry=2,
                ):
         self.save_dir = os.path.abspath(save_dir if save_dir is not None else (os.getcwd() + '/export/'))
         self.zip_enable = zip_enable
         self.zip_filepath = os.path.abspath(zip_filepath)
         self.zip_password = zip_password
         self.delete_original_file = delete_original_file
+        self.max_retry = max(1, int(max_retry))
         self.files = []
+        self.failed_folders = []
 
         mkdir_if_not_exists(self.save_dir)
         mkdir_if_not_exists(of_dir_path(self.zip_filepath))
@@ -1127,6 +1130,9 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
             apply_each_obj_func=bind_jm_task_context(self.handle_folder),
         )
 
+        # 汇总导出失败的收藏夹，避免数据静默缺失
+        self.raise_if_failed_folders()
+
         if not self.zip_enable:
             return
 
@@ -1143,18 +1149,61 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
     def handle_folder(self, fid: str, fname: str):
         self.log(f'【收藏夹: {fname}, fid: {fid}】开始获取数据')
 
-        # 获取收藏夹数据
-        page_data = self.fetch_folder_page_data(fid)
+        for attempt in range(1, self.max_retry + 1):
+            try:
+                # 获取收藏夹数据
+                page_data = self.fetch_folder_page_data(fid)
 
-        # 序列化到文件
-        filepath = self.save_folder_page_data_to_file(page_data, fid, fname)
+                # 序列化到文件
+                filepath = self.save_folder_page_data_to_file(page_data, fid, fname)
+            except Exception as e:
+                # 单个收藏夹失败不应该中断其他收藏夹，
+                # 但也不能无声无息地丢掉这份数据，这里记录并在结束后统一汇报
+                self.log(f'【收藏夹: {fname}, fid: {fid}】第 {attempt}/{self.max_retry} 次获取失败: [{e}]')
 
-        if filepath is None:
-            self.log(f'【收藏夹: {fname}, fid: {fid}】收藏夹无数据')
+                if attempt >= self.max_retry:
+                    self.failed_folders.append((fid, fname, e))
+                    return
+
+                self.retry_backoff(attempt)
+                continue
+
+            if filepath is None:
+                self.log(f'【收藏夹: {fname}, fid: {fid}】收藏夹无数据')
+                return
+
+            self.log(f'【收藏夹: {fname}, fid: {fid}】保存文件成功 → [{filepath}]')
+            self.files.append(filepath)
             return
 
-        self.log(f'【收藏夹: {fname}, fid: {fid}】保存文件成功 → [{filepath}]')
-        self.files.append(filepath)
+    # noinspection PyMethodMayBeStatic
+    def retry_backoff(self, attempt: int):
+        """
+        重试前的等待，避免短时间内反复请求加剧服务端限流。
+
+        :param attempt: 当前是第几次尝试（从 1 开始）
+        """
+        import time
+
+        time.sleep(min(2 ** attempt, 10))
+
+    def raise_if_failed_folders(self):
+        """
+        导出结束后统一检查失败的收藏夹。
+
+        收藏夹数据量大、耗时长时，登录态可能在服务端被提前过期，
+        导致个别收藏夹抓取失败；这类失败此前会被静默吞掉，导出的结果看起来
+        是成功的、实际却缺了数据。这里统一抛错，交由 option 的 safe 策略处理，
+        保证失败不会被忽略。
+        """
+        if not self.failed_folders:
+            return
+
+        detail = '、'.join(f'【{fname}】(fid={fid})' for fid, fname, _ in self.failed_folders)
+        msg = (f'以下 {len(self.failed_folders)} 个收藏夹导出失败（已重试 {self.max_retry} 次）: {detail}。'
+               f'可稍后重新执行导出以补全这部分数据。')
+        self.log(msg)
+        raise PluginValidationException(self, msg)
 
     def fetch_folder_page_data(self, fid):
         # 一页一页获取，不使用并行

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -1104,7 +1104,9 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
         self.zip_filepath = os.path.abspath(zip_filepath)
         self.zip_password = zip_password
         self.delete_original_file = delete_original_file
-        self.max_retry = max(1, int(max_retry))
+        # max_retry 表示「首次失败后的重试次数」，所以总尝试次数是 max_retry + 1。
+        # 允许配 0 表示不重试（只尝试一次），不要把它强行抬成 1。
+        self.max_retry = max(0, int(max_retry))
         self.files = []
         self.failed_folders = []
 
@@ -1130,26 +1132,26 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
             apply_each_obj_func=bind_jm_task_context(self.handle_folder),
         )
 
+        # 压缩导出的文件（放在失败检查之前：即便有收藏夹失败，
+        # 已经成功抓下来的那部分也应该照常打包，不能因为一个收藏夹失败就丢掉整批数据）
+        if self.zip_enable:
+            self.require_param(self.zip_filepath, '如果开启zip，请指定zip_filepath参数（压缩文件保存路径）')
+
+            if self.zip_password is None:
+                self.zip_folder_without_password(self.files, self.zip_filepath)
+            else:
+                self.zip_with_password()
+
+            self.execute_deletion(self.files)
+
         # 汇总导出失败的收藏夹，避免数据静默缺失
         self.raise_if_failed_folders()
-
-        if not self.zip_enable:
-            return
-
-        # 压缩导出的文件
-        self.require_param(self.zip_filepath, '如果开启zip，请指定zip_filepath参数（压缩文件保存路径）')
-
-        if self.zip_password is None:
-            self.zip_folder_without_password(self.files, self.zip_filepath)
-        else:
-            self.zip_with_password()
-
-        self.execute_deletion(self.files)
 
     def handle_folder(self, fid: str, fname: str):
         self.log(f'【收藏夹: {fname}, fid: {fid}】开始获取数据')
 
-        for attempt in range(1, self.max_retry + 1):
+        # 第 0 次是首次尝试，之后每次都是重试；总共 1 + max_retry 次
+        for attempt in range(self.max_retry + 1):
             try:
                 # 获取收藏夹数据
                 page_data = self.fetch_folder_page_data(fid)
@@ -1159,13 +1161,13 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
             except Exception as e:
                 # 单个收藏夹失败不应该中断其他收藏夹，
                 # 但也不能无声无息地丢掉这份数据，这里记录并在结束后统一汇报
-                self.log(f'【收藏夹: {fname}, fid: {fid}】第 {attempt}/{self.max_retry} 次获取失败: [{e}]')
+                self.log(f'【收藏夹: {fname}, fid: {fid}】第 {attempt + 1}/{self.max_retry + 1} 次获取失败: [{e}]')
 
                 if attempt >= self.max_retry:
                     self.failed_folders.append((fid, fname, e))
                     return
 
-                self.retry_backoff(attempt)
+                self.retry_backoff(attempt + 1)
                 continue
 
             if filepath is None:
@@ -1185,6 +1187,7 @@ class FavoriteFolderExportPlugin(JmOptionPlugin):
         """
         import time
 
+        # attempt 从 1 开始，首次重试等 2s，之后 4s、8s，上限 10s
         time.sleep(min(2 ** attempt, 10))
 
     def raise_if_failed_folders(self):

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -143,3 +143,98 @@ class Test_Plugin(JmTestConfigurable):
             print('✅ author falls back to DEFAULT_AUTHOR when authors is empty.')
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_favorite_folder_export_retry_and_failure_report(self):
+        """
+        source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/447
+
+        收藏夹导出时，单个收藏夹抓取失败不应该被静默丢掉：
+        1. 失败的收藏夹会按 max_retry 重试
+        2. 重试仍失败的收藏夹会被汇总抛出，而不是无声无息
+        3. 成功的收藏夹不受影响
+        """
+        import tempfile
+        import shutil
+        from unittest.mock import patch
+
+        from jmcomic.jm_plugin import FavoriteFolderExportPlugin, PluginValidationException
+
+        option = self.new_option()
+        tmp = tempfile.mkdtemp(prefix='jm_test_fav_export_')
+        try:
+            plugin = FavoriteFolderExportPlugin(option)
+            plugin.save_dir = tmp
+            plugin.zip_enable = False
+            plugin.zip_filepath = os.path.abspath(os.path.join(tmp, 'export.zip'))
+            plugin.zip_password = None
+            plugin.delete_original_file = False
+            plugin.max_retry = 3
+            plugin.files = []
+            plugin.failed_folders = []
+
+            fetch_calls = []
+
+            def fake_fetch(fid):
+                fetch_calls.append(fid)
+                if fid == 'bad':
+                    raise RuntimeError('会话已失效')
+                return ['page']
+
+            def fake_save(page_data, fid, fname):
+                return os.path.join(tmp, f'{fid}.csv')
+
+            with (
+                patch.object(plugin, 'fetch_folder_page_data', side_effect=fake_fetch),
+                patch.object(plugin, 'save_folder_page_data_to_file', side_effect=fake_save),
+                patch.object(plugin, 'retry_backoff'),
+            ):
+                plugin.handle_folder('good', '正常收藏夹')
+                plugin.handle_folder('bad', '坏掉的收藏夹')
+
+                # 正常收藏夹只取一次，失败的收藏夹重试 max_retry 次
+                self.assertEqual(['good', 'bad', 'bad', 'bad'], fetch_calls)
+                self.assertEqual([os.path.join(tmp, 'good.csv')], plugin.files)
+                self.assertEqual(1, len(plugin.failed_folders))
+                self.assertEqual('bad', plugin.failed_folders[0][0])
+
+                # 导出结束后应抛出明确异常，而不是静默返回
+                with self.assertRaises(PluginValidationException) as ctx:
+                    plugin.raise_if_failed_folders()
+                self.assertIn('坏掉的收藏夹', ctx.exception.msg)
+                self.assertIn('导出失败', ctx.exception.msg)
+            print('✅ Failed folder retried and reported instead of being dropped silently.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_favorite_folder_export_all_success_does_not_raise(self):
+        """全部成功时导出不应抛出异常。"""
+        import tempfile
+        import shutil
+        from unittest.mock import patch
+
+        from jmcomic.jm_plugin import FavoriteFolderExportPlugin
+
+        option = self.new_option()
+        tmp = tempfile.mkdtemp(prefix='jm_test_fav_ok_')
+        try:
+            plugin = FavoriteFolderExportPlugin(option)
+            plugin.save_dir = tmp
+            plugin.zip_enable = False
+            plugin.zip_filepath = os.path.abspath(os.path.join(tmp, 'export.zip'))
+            plugin.max_retry = 2
+            plugin.files = []
+            plugin.failed_folders = []
+
+            saved = os.path.join(tmp, '1.csv')
+            with (
+                patch.object(plugin, 'fetch_folder_page_data', return_value=['page']),
+                patch.object(plugin, 'save_folder_page_data_to_file', return_value=saved),
+            ):
+                plugin.handle_folder('1', '收藏夹1')
+
+            self.assertEqual([saved], plugin.files)
+            self.assertEqual([], plugin.failed_folders)
+            plugin.raise_if_failed_folders()
+            print('✅ Successful export raises nothing.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -149,7 +149,7 @@ class Test_Plugin(JmTestConfigurable):
         source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/447
 
         收藏夹导出时，单个收藏夹抓取失败不应该被静默丢掉：
-        1. 失败的收藏夹会按 max_retry 重试
+        1. 失败的收藏夹会按 max_retry 重试（max_retry 指重试次数，总尝试次数是 max_retry + 1）
         2. 重试仍失败的收藏夹会被汇总抛出，而不是无声无息
         3. 成功的收藏夹不受影响
         """
@@ -191,8 +191,8 @@ class Test_Plugin(JmTestConfigurable):
                 plugin.handle_folder('good', '正常收藏夹')
                 plugin.handle_folder('bad', '坏掉的收藏夹')
 
-                # 正常收藏夹只取一次，失败的收藏夹重试 max_retry 次
-                self.assertEqual(['good', 'bad', 'bad', 'bad'], fetch_calls)
+                # 正常收藏夹只取一次；失败的收藏夹共尝试 max_retry + 1 次（首次 + 3 次重试）
+                self.assertEqual(['good', 'bad', 'bad', 'bad', 'bad'], fetch_calls)
                 self.assertEqual([os.path.join(tmp, 'good.csv')], plugin.files)
                 self.assertEqual(1, len(plugin.failed_folders))
                 self.assertEqual('bad', plugin.failed_folders[0][0])
@@ -236,5 +236,111 @@ class Test_Plugin(JmTestConfigurable):
             self.assertEqual([], plugin.failed_folders)
             plugin.raise_if_failed_folders()
             print('✅ Successful export raises nothing.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_favorite_folder_export_max_retry_zero(self):
+        """
+        max_retry=0 表示不重试：只尝试一次，失败后直接记进 failed_folders。
+        """
+        import tempfile
+        import shutil
+        from unittest.mock import patch
+
+        from jmcomic.jm_plugin import FavoriteFolderExportPlugin
+
+        option = self.new_option()
+        tmp = tempfile.mkdtemp(prefix='jm_test_fav_zero_')
+        try:
+            plugin = FavoriteFolderExportPlugin(option)
+            plugin.save_dir = tmp
+            plugin.zip_enable = False
+            plugin.zip_filepath = os.path.abspath(os.path.join(tmp, 'export.zip'))
+            plugin.max_retry = 0
+            plugin.files = []
+            plugin.failed_folders = []
+
+            fetch_calls = []
+
+            def fake_fetch(fid):
+                fetch_calls.append(fid)
+                raise RuntimeError('会话已失效')
+
+            with (
+                patch.object(plugin, 'fetch_folder_page_data', side_effect=fake_fetch),
+                patch.object(plugin, 'retry_backoff'),
+            ):
+                plugin.handle_folder('bad', '坏掉的收藏夹')
+
+            # max_retry=0 → 只尝试一次，不应出现重试
+            self.assertEqual(['bad'], fetch_calls)
+            self.assertEqual(1, len(plugin.failed_folders))
+            print('✅ max_retry=0 means no retry, single attempt only.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_favorite_folder_export_zips_successful_files_before_raising(self):
+        """
+        开启 zip 时，即使有收藏夹导出失败，成功抓下来的文件也应该先打包完成，
+        再统一抛出失败汇总——不能因为一个收藏夹失败就把整批已成功的数据丢掉。
+        """
+        import tempfile
+        import shutil
+        from unittest.mock import patch
+
+        from jmcomic.jm_plugin import FavoriteFolderExportPlugin, PluginValidationException
+
+        option = self.new_option()
+        tmp = tempfile.mkdtemp(prefix='jm_test_fav_zip_')
+        try:
+            plugin = FavoriteFolderExportPlugin(option)
+            plugin.save_dir = tmp
+            plugin.zip_enable = True
+            plugin.zip_filepath = os.path.abspath(os.path.join(tmp, 'export.zip'))
+            plugin.zip_password = None
+            plugin.delete_original_file = False
+            plugin.max_retry = 0
+            plugin.files = []
+            plugin.failed_folders = []
+
+            # 模拟 main() 里的收藏夹枚举结果
+            class FakePage:
+                def iter_folder_id_name(self):
+                    return [('good', '正常收藏夹'), ('bad', '坏掉的收藏夹')]
+
+            class FakeClient:
+                def favorite_folder(self):
+                    return FakePage()
+
+            zipped = []
+            deleted = []
+
+            def fake_fetch(fid):
+                if fid == 'bad':
+                    raise RuntimeError('会话已失效')
+                return ['page']
+
+            def fake_zip(files, filepath):
+                zipped.append(list(files))
+
+            with (
+                patch.object(plugin, 'build_client', create=True, return_value=FakeClient()),
+                patch.object(plugin, 'fetch_folder_page_data', side_effect=fake_fetch),
+                patch.object(plugin, 'save_folder_page_data_to_file',
+                             side_effect=lambda page_data, fid, fname: os.path.join(tmp, f'{fid}.csv')),
+                patch.object(plugin, 'zip_folder_without_password', side_effect=fake_zip),
+                patch.object(plugin, 'execute_deletion', side_effect=lambda files: deleted.append(list(files))),
+            ):
+                # main() 里通过 option.build_jm_client 拿 client，这里直接替换 option 的方法
+                with patch.object(plugin.option, 'build_jm_client', return_value=FakeClient()):
+                    with self.assertRaises(PluginValidationException):
+                        plugin.main()
+
+            # 成功的文件必须先被打包，且打包发生在抛错之前
+            self.assertEqual(1, len(zipped))
+            self.assertIn(os.path.join(tmp, 'good.csv'), zipped[0])
+            self.assertNotIn(os.path.join(tmp, 'bad.csv'), zipped[0])
+            self.assertEqual(1, len(deleted))
+            print('✅ Successful files zipped before the failure summary is raised.')
         finally:
             shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -303,7 +303,9 @@ class Test_Plugin(JmTestConfigurable):
             plugin.files = []
             plugin.failed_folders = []
 
-            # 模拟 main() 里的收藏夹枚举结果
+            # 模拟 main() 里的收藏夹枚举结果。
+            # 注意 '0'（特殊收藏栏【全部】）也会被 main() 枚举到，
+            # 所以这里必须显式让它无数据，否则会平白多出一个导出文件。
             class FakePage:
                 def iter_folder_id_name(self):
                     return [('good', '正常收藏夹'), ('bad', '坏掉的收藏夹')]
@@ -314,22 +316,27 @@ class Test_Plugin(JmTestConfigurable):
 
             zipped = []
             deleted = []
+            events = []
 
             def fake_fetch(fid):
-                if fid == 'bad':
+                if fid in ('bad', '0'):
                     raise RuntimeError('会话已失效')
                 return ['page']
 
             def fake_zip(files, filepath):
                 zipped.append(list(files))
+                events.append('zip')
+
+            def fake_delete(files):
+                deleted.append(list(files))
+                events.append('delete')
 
             with (
-                patch.object(plugin, 'build_client', create=True, return_value=FakeClient()),
                 patch.object(plugin, 'fetch_folder_page_data', side_effect=fake_fetch),
                 patch.object(plugin, 'save_folder_page_data_to_file',
                              side_effect=lambda page_data, fid, fname: os.path.join(tmp, f'{fid}.csv')),
                 patch.object(plugin, 'zip_folder_without_password', side_effect=fake_zip),
-                patch.object(plugin, 'execute_deletion', side_effect=lambda files: deleted.append(list(files))),
+                patch.object(plugin, 'execute_deletion', side_effect=fake_delete),
             ):
                 # main() 里通过 option.build_jm_client 拿 client，这里直接替换 option 的方法
                 with patch.object(plugin.option, 'build_jm_client', return_value=FakeClient()):
@@ -338,9 +345,111 @@ class Test_Plugin(JmTestConfigurable):
 
             # 成功的文件必须先被打包，且打包发生在抛错之前
             self.assertEqual(1, len(zipped))
-            self.assertIn(os.path.join(tmp, 'good.csv'), zipped[0])
-            self.assertNotIn(os.path.join(tmp, 'bad.csv'), zipped[0])
+            self.assertEqual([os.path.join(tmp, 'good.csv')], zipped[0])
             self.assertEqual(1, len(deleted))
+            # 打包必须先于删源，否则删源会把还没进包的源文件删掉
+            self.assertEqual(['zip', 'delete'], events)
             print('✅ Successful files zipped before the failure summary is raised.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_favorite_folder_export_encrypted_zip_only_includes_exported_files(self):
+        """
+        zip_password 非空时走 7z 加密打包，同样只能打包本次导出的文件。
+
+        原实现是 `7z a "{zip}" "./"`，会把 save_dir 下的一切都卷进去：
+        上一轮遗留的旧导出、失败收藏夹写了一半的 csv。
+        这些文件不在 execute_deletion 的删除范围内，等于往产物里混入无关数据。
+        """
+        import tempfile
+        import shutil
+        from unittest.mock import patch
+
+        from jmcomic.jm_plugin import FavoriteFolderExportPlugin, PluginValidationException
+
+        option = self.new_option()
+        tmp = tempfile.mkdtemp(prefix='jm_test_fav_enc_')
+        try:
+            # 干扰项：历史遗留导出 + 失败留下的半截文件
+            stale = os.path.join(tmp, 'old_export.csv')
+            half = os.path.join(tmp, 'bad.csv')
+            with open(stale, 'w', encoding='utf-8') as f:
+                f.write('id,author,name\n9,z,w\n')
+            with open(half, 'w', encoding='utf-8') as f:
+                f.write('id,author,name\n2,b,y\n')
+
+            plugin = FavoriteFolderExportPlugin(option)
+            plugin.save_dir = tmp
+            plugin.zip_enable = True
+            plugin.zip_filepath = os.path.abspath(os.path.join(tmp, 'export.zip'))
+            plugin.zip_password = 'secret'
+            plugin.delete_original_file = False
+            plugin.max_retry = 0
+            plugin.files = []
+            plugin.failed_folders = []
+
+            class FakePage:
+                def iter_folder_id_name(self):
+                    return [('good', '正常收藏夹'), ('bad', '坏掉的收藏夹')]
+
+            class FakeClient:
+                def favorite_folder(self):
+                    return FakePage()
+
+            def fake_fetch(fid):
+                if fid in ('bad', '0'):
+                    raise RuntimeError('会话已失效')
+                return ['page']
+
+            captured = {}
+
+            def fake_zip_with_password(files, zip_path):
+                captured['files'] = list(files)
+
+            with (
+                patch.object(plugin, 'fetch_folder_page_data', side_effect=fake_fetch),
+                patch.object(plugin, 'save_folder_page_data_to_file',
+                             side_effect=lambda page_data, fid, fname: os.path.join(tmp, f'{fid}.csv')),
+                patch.object(plugin, 'zip_with_password', side_effect=fake_zip_with_password),
+                patch.object(plugin, 'execute_deletion'),
+            ):
+                with patch.object(plugin.option, 'build_jm_client', return_value=FakeClient()):
+                    with self.assertRaises(PluginValidationException):
+                        plugin.main()
+
+            self.assertEqual([os.path.join(tmp, 'good.csv')], captured['files'])
+            self.assertNotIn(stale, captured['files'])
+            self.assertNotIn(half, captured['files'])
+            print('✅ Encrypted zip receives only this run\'s exported files.')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_zip_with_password_does_not_archive_whole_save_dir(self):
+        """7z 命令必须逐个列举文件，不能再用 './' 打包整个 save_dir。"""
+        import tempfile
+        import shutil
+        from unittest.mock import patch
+
+        from jmcomic.jm_plugin import FavoriteFolderExportPlugin
+
+        option = self.new_option()
+        tmp = tempfile.mkdtemp(prefix='jm_test_7z_cmd_')
+        try:
+            plugin = FavoriteFolderExportPlugin(option)
+            plugin.save_dir = tmp
+            plugin.zip_filepath = os.path.abspath(os.path.join(tmp, 'out.zip'))
+            plugin.zip_password = 'secret'
+
+            good = os.path.join(tmp, 'good.csv')
+            cmds = []
+            with patch.object(plugin, 'execute_multi_line_cmd', side_effect=cmds.append):
+                plugin.zip_with_password([good], plugin.zip_filepath)
+
+            self.assertEqual(1, len(cmds))
+            cmd = cmds[0]
+            self.assertIn('good.csv', cmd)
+            self.assertNotIn('"./"', cmd)
+            self.assertNotIn("'./'", cmd)
+            print('✅ 7z command enumerates files instead of archiving "./".')
         finally:
             shutil.rmtree(tmp, ignore_errors=True)


### PR DESCRIPTION
#447 收藏夹导出少数据的问题，按 issue 里的讨论试着修了一下。

根因大概是这样：`favorite_folder_export` 给每个收藏夹开一个线程，默认收藏夹数据量大、跑得久，中途登录态会被服务端提前过期，那个线程就报错退出了。而 `handle_folder` 里没有异常处理，失败直接被吞掉，所以导出结果看着是成功的，实际缺了收藏夹（#447 里 @White-Frill 也提到重跑一次结果还不一样）。

改动：

- `handle_folder` 加了重试（`max_retry`，默认 2 次），失败后等一会儿再试，避免短时间内反复请求
- 重试仍失败的收藏夹统一收集，导出结束后报错（走 option 的 safe 策略），不再无声无息地丢数据
- 成功的收藏夹不受影响

这块参考了 batch 下载里 `_safe_download` 的做法——异常收集而不是静默丢失。

测试：新增两个用例，mock 掉抓取与写文件，验证失败的收藏夹会按 `max_retry` 重试、成功的收藏夹不受影响、全部成功时不报错。本地跑过：

```
python -m unittest test_jmcomic.test_jm_plugin.Test_Plugin.test_favorite_folder_export_retry_and_failure_report -v
```

---

说明一下没做的部分：登录态被提前过期，理论上要重新登录才能恢复，那需要动到 client 层。这次先把「失败可见 + 重试」补上，重登机制要不要做、怎么做，看你的想法。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed folder exports are now retried automatically, with configurable retry limits.
  * Permanently failed folders are reported instead of silently skipped.
  * Successfully exported files are packaged before failures are reported.
  * Archives now include only files exported during the current operation, avoiding stale or incomplete files.
  * Export operations clearly indicate when one or more folders could not be exported.

* **Tests**
  * Added coverage for retry behavior, failure reporting, and archive contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->