### PR TITLE
feat(plugin): calibre_metadata 的 OPF 生成改由 jmcomic-calibre 提供

### DIFF
--- a/.github/requirements-dev.txt
+++ b/.github/requirements-dev.txt
@@ -9,3 +9,4 @@ rich
 jm-view-server
 zhconv
 img2pdf
+jmcomic-calibre @ https://github.com/yifenliwu/jmcomic-calibre/archive/refs/tags/v0.2.0.tar.gz

--- a/src/jmcomic/jm_plugin.py
+++ b/src/jmcomic/jm_plugin.py
@@ -1855,6 +1855,9 @@ class CalibreMetadataPlugin(JmOptionPlugin):
     通常挂在 after_album 上，每个本子在其目录下生成一份 metadata.opf，
     Calibre 导入（从 OPF 读元数据）时可以自动带上书名、作者、标签、简介和封面。
 
+    OPF 的生成逻辑由 jmcomic-calibre 提供（pip install jmcomic-calibre），
+    避免同一份 XML 拼接逻辑在两处各维护一份。
+
     配置示例：
 
     ```yml
@@ -1877,13 +1880,6 @@ class CalibreMetadataPlugin(JmOptionPlugin):
     """
     plugin_key = 'calibre_metadata'
 
-    # fields 允许的 Dublin Core 元素名（核心15元素），避免非法元素名生成无效 XML
-    DUBLIN_CORE_ELEMENTS = frozenset({
-        'title', 'creator', 'subject', 'description', 'publisher', 'contributor',
-        'date', 'type', 'format', 'identifier', 'source', 'language', 'relation',
-        'coverage', 'rights',
-    })
-
     def invoke(self,
                dir_rule: dict,
                album: JmAlbumDetail = None,
@@ -1892,66 +1888,27 @@ class CalibreMetadataPlugin(JmOptionPlugin):
                include_cover=False,
                fields=None,
                **kwargs) -> None:
-        from xml.sax.saxutils import escape
-
         self.require_param(album, '本插件需在after_album阶段使用，需要album参数')
+
+        try:
+            import jmcomic_calibre
+        except ImportError:
+            self.warning_lib_not_install('jmcomic-calibre')
+            return
+
         opf_path = self.decide_filepath(album, photo, None, None, None, dir_rule)
-        opf_dir = os.path.dirname(opf_path)
 
-        fields = dict(fields or {})
-
-        # 标题与作者，允许通过 fields 覆盖；作者为空时由 album.author 兜底为 DEFAULT_AUTHOR
-        title = str(fields.pop('title', album.title))
-        author = str(fields.pop('author', album.author))
-
-        # 封面：与 metadata.opf 同目录存放 cover.jpg，并在 OPF 中引用
-        cover_line = ''
-        manifest_line = ''
-        if include_cover:
-            cover_path = os.path.join(opf_dir, 'cover.jpg')
-            self.download_cover_if_needed(album.id, cover_path, downloader)
-            manifest_line = (
-                '  <manifest>\n'
-                '    <item id="cover-image" href="cover.jpg" media-type="image/jpeg"/>\n'
-                '  </manifest>\n'
-            )
-            cover_line = '  <meta name="cover" content="cover-image"/>\n'
-
-        subject_lines = ''.join(
-            f'  <dc:subject>{escape(str(tag))}</dc:subject>\n'
-            for tag in (album.tags or [])
+        jmcomic_calibre.export_opf(
+            album=album,
+            opf_path=opf_path,
+            fields=fields,
+            include_cover=include_cover,
+            download_cover=lambda cover_path: self.download_cover_if_needed(
+                album.id, cover_path, downloader),
+            on_ignored=lambda key, allowed: self.log(
+                f'calibre_metadata: 忽略不支持的fields字段 [{key}]，'
+                f'仅支持Dublin Core元素: {", ".join(sorted(allowed))}', 'warning'),
         )
-
-        extra_lines = ''
-        for key, value in fields.items():
-            key = str(key)
-            if key not in self.DUBLIN_CORE_ELEMENTS:
-                self.log(f'calibre_metadata: 忽略不支持的fields字段 [{key}]，'
-                         f'仅支持Dublin Core元素: {", ".join(sorted(self.DUBLIN_CORE_ELEMENTS))}', 'warning')
-                continue
-            extra_lines += f'  <dc:{key}>{escape(str(value))}</dc:{key}>\n'
-
-        xml = (
-            '<?xml version="1.0" encoding="utf-8"?>\n'
-            '<package version="2.0" xmlns="http://www.idpf.org/2007/opf"\n'
-            '        xmlns:dc="http://purl.org/dc/elements/1.1/"\n'
-            '        xmlns:opf="http://www.idpf.org/2007/opf">\n'
-            '  <metadata>\n'
-            f'    <dc:title>{escape(title)}</dc:title>\n'
-            f'    <dc:creator opf:role="aut">{escape(author)}</dc:creator>\n'
-            f'{subject_lines}'
-            f'    <dc:identifier opf:scheme="JMCOMIC">jmcomic:{album.id}</dc:identifier>\n'
-            f'    <dc:description>{escape(album.description)}</dc:description>\n'
-            f'{extra_lines}'
-            f'{cover_line}'
-            '  </metadata>\n'
-            f'{manifest_line}'
-            '</package>\n'
-        )
-
-        mkdir_if_not_exists(opf_dir)
-        with open(opf_path, 'w', encoding='utf-8') as f:
-            f.write(xml)
         self.log(f'已生成Calibre元数据文件 → [{opf_path}]')
 
     def download_cover_if_needed(self, album_id: str, cover_path: str, downloader):

--- a/tests/test_jmcomic/test_jm_plugin.py
+++ b/tests/test_jmcomic/test_jm_plugin.py
@@ -1,5 +1,11 @@
 from test_jmcomic import *
 
+try:
+    import jmcomic_calibre  # noqa: F401
+    HAS_JMCOMIC_CALIBRE = True
+except ImportError:
+    HAS_JMCOMIC_CALIBRE = False
+
 
 class Test_Plugin(JmTestConfigurable):
 
@@ -36,11 +42,15 @@ class Test_Plugin(JmTestConfigurable):
         download_photo(photo_id, option, downloader=DoNotDownloadImage)
         print('✅ All folder rule plugins assert completed safely without KeyError.')
 
+    @unittest.skipUnless(
+        HAS_JMCOMIC_CALIBRE,
+        '这条用例依赖 jmcomic-calibre 生成 OPF：pip install jmcomic-calibre',
+    )
     def test_calibre_metadata(self):
         """
         source: https://github.com/hect0x7/JMComic-Crawler-Python/issues/573
 
-        测试 calibre_metadata 插件：
+        测试 calibre_metadata 插件（OPF 由 jmcomic-calibre 生成）：
         1. after_album 阶段生成 metadata.opf，包含书名/作者/标签/identifier
         2. fields 静态字段（如 language）按维护者建议写入
         3. 作者为空时兜底 DEFAULT_AUTHOR；XML 特殊字符正确转义


### PR DESCRIPTION
按你说的，把 OPF 拼接挪到 jmcomic-calibre 了，插件现在只算路径 + 传参：

```python
jmcomic_calibre.export_opf(album=album, opf_path=opf_path, fields=fields,
                          include_cover=include_cover, download_cover=..., on_ignored=...)
```

没装库就 `warning_lib_not_install('jmcomic-calibre')` 然后返回。这里有个行为变化要说一下：以前插件是零外部依赖的，现在要装 `jmcomic-calibre` 才会生成 opf。

输出我对着 `test_calibre_metadata` 的断言逐条比过，跟改之前完全一致：title/creator/subjects/identifier/description 都在，fields 里的 language 生效，`series index` 这种非法键照样忽略并告警，include_cover=True 还是写 cover.jpg + manifest。空作者回落到 `JmModuleConfig.DEFAULT_AUTHOR` 也一致——走的是 `album.author`，没有另立一套默认值。

动了三个文件：

- `src/jmcomic/jm_plugin.py`：插件改成调库，删掉内联的 XML 拼接
- `tests/test_jmcomic/test_jm_plugin.py`：加 skipUnless，没装库时跳过这条用例
- `.github/requirements-dev.txt`：加 `jmcomic-calibre`（指向 v0.2.0 的归档），这样 CI 能真跑到这条路径

最后那一行如果你不想让 CI 去拉外部仓库，删掉就行，用例会自己 skip 掉。

库在这：https://github.com/yifenliwu/jmcomic-calibre ，`export_opf` 单独有 10 条单测，3.9/3.12 CI 是绿的。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Calibre metadata export now uses the updated export workflow, improving compatibility and consistency when creating metadata files.
  - Cover handling and ignored metadata fields are processed more reliably during export.

- **Bug Fixes**
  - Added clearer handling when Calibre metadata support is unavailable, including an appropriate warning instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->